### PR TITLE
BISERVER-8578 - need to pass in the click handler for the view blockouts button since the dialog was defined in user-console

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/controls/schededitor/ScheduleEditor.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/controls/schededitor/ScheduleEditor.java
@@ -25,6 +25,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.CaptionPanel;
 import com.google.gwt.user.client.ui.ClickListener;
@@ -254,6 +255,10 @@ public class ScheduleEditor extends VerticalPanel implements IChangeHandler  {
 
     configureOnChangeHandler();
   }
+
+    public void setBlockoutButtonHandler(final ClickHandler handler) {
+        blockoutCheckButton.addClickHandler(handler);
+    }
 
 
   public TimePicker getStartTimePicker()


### PR DESCRIPTION
BISERVER-8578 - need to pass in the click handler for the view blockouts button since the dialog was defined in user-console
