### PR TITLE
BISERVER-8882 - Standards Mode Doc Type Issues

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/public/Widgets.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/public/Widgets.css
@@ -839,7 +839,7 @@ input[type=password]:focus {
 }
 
 .gwt-ScrollTable .headerWrapper {
-  background: #d2d2d2 repeat-x scroll left bottom;
+  background: #d2d2d2 scroll left bottom;
   padding-right: 0px;
 }
 
@@ -878,7 +878,7 @@ input[type=password]:focus {
 }
 
 .IE .gwt-ScrollTable .headerTable td {
-  background: url('images/header_20px.png') repeat-x;
+  background: url('images/header_20px.png');
 }
 
 .gwt-ScrollTable .headerTable-disabled td {


### PR DESCRIPTION
IE9: Table headings being cutoff 1/2 way down.
