### PR TITLE
BISERVER-8911 Blockout button appear for a moment when no blockouts exist when scheduling a report.

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/controls/schededitor/ScheduleEditor.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/controls/schededitor/ScheduleEditor.java
@@ -427,7 +427,8 @@ public class ScheduleEditor extends VerticalPanel implements IChangeHandler {
       // We want to add a button to check for blockout conflicts
       blockoutCheckButton.setStyleName("pentaho-button"); //$NON-NLS-1$
       blockoutCheckButton.getElement().setId("blockout-check-button"); //$NON-NLS-1$
-
+      blockoutCheckButton.setVisible(false);
+      
       hspacer.setHeight("50px"); //$NON-NLS-1$
       blockoutButtonPanel.add(hspacer);
       blockoutButtonPanel.add(blockoutCheckButton);


### PR DESCRIPTION
By default we now hide this button and show/hide this as was already being done (in PUC)
