### PR TITLE
Fix for BISERVER-8887

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/controls/schededitor/ScheduleEditor.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/controls/schededitor/ScheduleEditor.java
@@ -371,6 +371,7 @@ public class ScheduleEditor extends VerticalPanel implements IChangeHandler {
       HorizontalPanel blockoutStartPanel = new HorizontalPanel();
       blockoutStartPanel.add(getStartTimePicker());
       timeZonePicker = new ListBox();
+      timeZonePicker.setStyleName("timeZonePicker");
       timeZonePicker.setVisibleItemCount(1);
       blockoutStartPanel.add(timeZonePicker);
       timeZonePicker.getElement().getParentElement().getStyle().setPaddingTop(5, Unit.PX);

--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/public/Widgets.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/public/Widgets.css
@@ -1070,3 +1070,8 @@ input[type=password]:focus {
 	height: auto;
 	width: auto;
 }
+
+.timeZonePicker {
+  width: 100%; 
+}
+


### PR DESCRIPTION
FF and IE9 : The Create Blockout Time screen expands right after
opening. Go to the Schedules perspective and click on the Create
Blockout Time button.
