### PR TITLE
BISERVER-9147 - IE8 - Error received after login, cannot proceed.

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/utils/ElementUtils.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/utils/ElementUtils.java
@@ -108,9 +108,9 @@ public class ElementUtils {
   }
 
   public static native void preventTextSelection(Element ele) /*-{
-      //Handle all 3 browser types
-      var isWebkit = 'webkitRequestAnimationFrame' in $wnd;
-      if(ele.hasAttribute('style')){
+    // Handle all 3 browser types
+    var isWebkit = 'webkitRequestAnimationFrame' in $wnd;
+    if(ele.getAttribute('style') != null){
       //IE
       if(document.all){
         ele.onselectstart=function() {return false};


### PR DESCRIPTION
Replaced elem.hasAttribute call by elem.getAttribute !=null, because the former is not defined in IE8
