### PR TITLE
BISERVER-8967 - Making the busy indicator message wrap if it grows too long

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
@@ -2255,6 +2255,9 @@ background-color: transparent;
 .busy-indicator-container {
   display: block;
 }
+.busy-indicator-container-wrapper {
+  display: table;
+}
 .spinner {
 
 }
@@ -2276,22 +2279,20 @@ background-color: transparent;
   width: 16px;
 }
 .pentaho-busy-indicator-spinner {
-  display: inline-block;
-  float: left;
+  display: table-cell;
   width: 48px;
   height: 48px;
+  vertical-align: middle;
   padding: 20px;
 }
 .pentaho-busy-indicator-msg-contianer {
-  display: inline-block;
-  float: left;
+  display: table-cell;
   vertical-align: middle;
-  padding: 20px 0px;
 }
 
 .waitPopup {
   position: absolute;
-  width: 350px;
+  width: 330px;
   top: 44%;
   right: 0px;
   left: 0px;
@@ -2305,12 +2306,15 @@ background-color: transparent;
   color: #0560AB;
   font-size: 18px;
   padding-bottom: 3px;
+  width: 262px;
 }
 
 .waitPopup_msg {
   color: #6F777B;
   font-weight: normal;
   font-size: 14px;
+  white-space: normal;
+  width: 262px;
 }
 
 /* == == == == */

--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/onyx/globalOnyx.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/onyx/globalOnyx.css
@@ -2226,6 +2226,9 @@ input:focus {
 
 /* -- new spinner stuff -- */
 .busy-indicator-container {
+  display: block;
+}
+.busy-indicator-container-wrapper {
   display: table;
 }
 .spinner {
@@ -2252,18 +2255,21 @@ input:focus {
   display: table-cell;
   width: 48px;
   height: 48px;
+  vertical-align: middle;
+  padding: 20px;
 }
 .pentaho-busy-indicator-msg-contianer {
   display: table-cell;
   vertical-align: middle;
-  padding-left: 10px;
 }
 
 .waitPopup {
   position: absolute;
-  left: 44%;
+  width: 330px;
   top: 44%;
-  padding: 15px 8px;
+  right: 0px;
+  left: 0px;
+  margin: auto;
   z-index: 20001;
   height: auto;
   border: 1px solid #ccc;
@@ -2274,14 +2280,16 @@ input:focus {
   font-weight: bold;
   font-size: 16px;
   padding-bottom: 3px;
+  width: 262px;
 }
 
 .waitPopup_msg {
   color: #444;
   font-weight: normal;
   font-size: 13px;
+  white-space: normal;
+  width: 262px;
 }
-
 
 /* == == == == */
 .icon-small {

--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/slate/globalSlate.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/slate/globalSlate.css
@@ -2438,6 +2438,9 @@ body .dojoMenuItem2Hover {
 
 /* -- new spinner stuff -- */
 .busy-indicator-container {
+  display: block;
+}
+.busy-indicator-container-wrapper {
   display: table;
 }
 .spinner {
@@ -2464,18 +2467,21 @@ body .dojoMenuItem2Hover {
   display: table-cell;
   width: 48px;
   height: 48px;
+  vertical-align: middle;
+  padding: 20px;
 }
 .pentaho-busy-indicator-msg-contianer {
   display: table-cell;
   vertical-align: middle;
-  padding-left: 10px;
 }
 
 .waitPopup {
   position: absolute;
-  left: 44%;
+  width: 330px;
   top: 44%;
-  padding: 15px 8px;
+  right: 0px;
+  left: 0px;
+  margin: auto;
   z-index: 20001;
   height: auto;
   border: 1px solid #ccc;
@@ -2486,14 +2492,16 @@ body .dojoMenuItem2Hover {
   font-weight: bold;
   font-size: 16px;
   padding-bottom: 3px;
+  width: 262px;
 }
 
 .waitPopup_msg {
   color: #444;
   font-weight: normal;
   font-size: 13px;
+  white-space: normal;
+  width: 262px;
 }
-
 
 /* == == == == */
 


### PR DESCRIPTION
Also default the spinner color to #999 to account for the IE8 VML fallback option that doesn't allow for a css override of color like the css3 implementation.
