### PR TITLE
Fix for BISERVER-9198

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/filechooser/FileChooser.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/filechooser/FileChooser.java
@@ -676,10 +676,10 @@ public class FileChooser extends VerticalPanel {
   
   public boolean doesSelectedFileExist(String ext) {
     String fileName = this.selectedPath + "/" + this.actualFileName; //$NON-NLS-1$
-	  if(!StringUtils.isEmpty(ext)) {
-		  fileName = fileName + ext;
-	  }
-	  return search(fileTree, fileName) != null;
+	if(!StringUtils.isEmpty(ext) && !fileName.endsWith(ext)) {
+		fileName = fileName + ext;
+	}
+	return search(fileTree, fileName) != null;
   }
 
   public void setShowLocalizedFileNames(boolean showLocalizedFileNames) {


### PR DESCRIPTION
Save Report - Overwrite warning doesn't show when you save report with same name 
