### PR TITLE
Fix for BISERVER-9500

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/public/Widgets.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/public/Widgets.css
@@ -117,7 +117,7 @@ background-color: #cbefa3;
 }
 
 .disabledMenuItem {
-  color: gray;
+  color: #CCCCCC;
   cursor: Default;
   padding:3px 20px 3px 20px;
   vertical-align: bottom;


### PR DESCRIPTION
File Menu - Crystal Theme - Save and Save As buttons should be in
disabled color when buttons are disabled.
