### PR TITLE
PDB-1585 - Can't tie a dashboard prompt to a content's parameter - UI doesn't show dropdown

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
@@ -3158,10 +3158,19 @@ background-color: #8ab3c6;
 }
 #contentLinkingAssignmentTable .gwt-ScrollTable .headerTable td,
 #propertiesPanelParameterAssignmentTable .gwt-ScrollTable .headerTable td {
-  padding: 4px 10px 4px 10px;
+  padding-left:   0px;
+  padding-right:  0px;
   height: 20px;
   font-size: 14px;
 }
+
+#contentLinkingAssignmentTable .gwt-ScrollTable .dataTable>tbody>tr>td,
+#propertiesPanelParameterAssignmentTable .gwt-ScrollTable .dataTable>tbody>tr>td {
+    padding-left:  0px;
+    padding-right: 0px;
+}
+
+
 .gwt-ScrollTable .headerTable tr > td:last-of-type {
   border-right: 1px solid transparent;
 }

--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/onyx/globalOnyx.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/onyx/globalOnyx.css
@@ -2612,9 +2612,14 @@ input:focus {
 }
 #contentLinkingAssignmentTable .gwt-ScrollTable .headerTable td,
 #propertiesPanelParameterAssignmentTable .gwt-ScrollTable .headerTable td {
-  padding: 8px 10px 6px 10px;
+  padding: 8px 0px 6px 0px;
   height: 20px;
   font-size: 14px;
+}
+#contentLinkingAssignmentTable .gwt-ScrollTable .dataTable>tbody>tr>td,
+#propertiesPanelParameterAssignmentTable .gwt-ScrollTable .dataTable>tbody>tr>td {
+    padding-left:  0px;
+    padding-right: 0px;
 }
 .IE .headerTable td {
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr = '#FF777777', endColorstr = '#FF000000');


### PR DESCRIPTION
@rfellows:
- This is a **poor man's fix** - removes the horizontal cell paddings that mess-up the layout of the gwt-ScrollTable and prevent the user from seeing the drop-down arrow;
  **restores functionality at the cost of appearance**.
- What's happening is that the the way that the gwt widget _CustomListBox_ is using a style="100%" attribute in its top-level element.
- The CustomListBox control is within a td of "#propertiesPanelParameterAssignmentTable .gwt-ScrollTable" - the GWT/HTML representation of a XUL <tree> (of ddMainFrame.xul).
- The styles in the globalCrystal.css are applying paddings to the td -> 100% + 20px padding -> causes the drop-down arrow to appear of the cell.
- One way to fix this right would be removing the fixed style="width:100%" that is being set (somewhere???) in GWT code, and applying that as a default, in CSS instead: <br/>
  <pre>.custom-list: { width: 100%; }</pre>
  Then, as a CSS override to this _CustomListBox_ only:<br/> 
  <pre>{ left:0px, right:0px; padding-left: 10px; padding-right: 10px; }</pre>
  Also, to be able to correctly apply paddings to the table headers' text, without unwantedly enlarging the table width,
  each header text would need to be wrapped in a block element, and margins to it applied instead.
