### PR TITLE
BISERVER-10114 - IE10 only - Text selection in dialogs can cause the UI ...

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
@@ -409,6 +409,13 @@ div#FilterPanel div.pentaho-toggle-button-down button{
   position: absolute;
   background: #f5f6f8;
   padding: 8px 8px 0px 8px;
+
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: moz-none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .bootstrap .modal.pentaho-dialog {
@@ -425,13 +432,6 @@ div#FilterPanel div.pentaho-toggle-button-down button{
   -webkit-background-clip: none;
   -moz-background-clip: none;
   background-clip: none;
-
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: moz-none;
-  -ms-user-select: none;
-  user-select: none;
 }
 
 .pentaho-dialog #override-description {


### PR DESCRIPTION
...to lock up if you mouse over the Accellerators icon (blue and white icon)

Moving the user-select css to a less restrictive scope. before, all .boostrap .modal.pentaho-dialog already turned off users text selection. this change applies that to ALL .pentaho-dialogs as well.
