### PR TITLE
BISERVER-10313 - Data-source layout collapsed when using chrome 29&30 on Win2008r2

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
@@ -746,6 +746,18 @@ border-top: 4px solid transparent;
   border-left: 1px solid #cbdde8;
   height: 100%;
   background-color: #fff;
+  position: relative;
+}
+
+/* Webkit browsers only */
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+  .pentaho-tab-deck-panel>DIV {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    bottom: 0px;
+    right: 0px;
+  }
 }
 
   /* properties dialog panels */

--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/onyx/globalOnyx.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/onyx/globalOnyx.css
@@ -619,6 +619,18 @@ has no buttons add an addition class to your element, pentaho-dialog-buttonless,
     border-bottom: 1px solid #2B2B2B;
     border-left: 1px solid #2B2B2B;
     height: 100%;
+  position: relative;
+}
+
+/* Webkit browsers only */
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+  .pentaho-tab-deck-panel>DIV {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    bottom: 0px;
+    right: 0px;
+  }
 }
 
 .pucContentDeck .pentaho-tab-deck-panel {


### PR DESCRIPTION
BISERVER-10313 - Data-source layout collapsed when using chrome 29&30 on Win2008r2
