### PR TITLE
BISERVER-9590 - IE9 New Schedule Window - Crystal Theme - Next/Cancel buttons have no space between the buttons.

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
@@ -5227,3 +5227,7 @@ treecontrol.tree-classic li .tree-selected {
     background-color: #d7e9cd;
 }
 
+.schedule-dialog-button-panel tr td button.pentaho-button{
+	margin-left:2px;
+	margin-right:2px;
+}


### PR DESCRIPTION
What was done:
1) added margin to the buttons
