### PR TITLE
[BISERVER-11287] - Settings buttons do not have enough distance.

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
@@ -204,6 +204,8 @@ input, input[type="password"]{
   white-space: nowrap;
   /*text-shadow: 0px 0px 2px rgba(000, 000, 000, 1);*/
   cursor: pointer;
+  /* Chrome has a default 2px margin for buttons in user agent stylesheet rule */
+  margin: 0px;
 }
 
   /* Applies the green glow to buttons */


### PR DESCRIPTION
- Resetting chrome only user-agent stylesheet rule:  button { margin:2px; }
- Not having a margin reset causes different browsers to show different margins
- In this case, Chrome had enough distance, due to the Chrome only rule, while all, or almost all other browsers did not.

@pamval please review.
