### PR TITLE
[PDI-12181] - Instaview Metedata Modeling - Cannot change measure format.

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/listbox/CustomListBox.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/listbox/CustomListBox.java
@@ -1158,7 +1158,11 @@ public class CustomListBox extends HorizontalPanel implements ChangeListener, Po
    */
   public String getValue() {
     if ( !editable ) {
-      return null;
+      if( getSelectedItem() != null ) {
+        return getSelectedItem().getText();
+      } else {
+        return null;
+      }
     } else {
       return ( editableTextBox != null ) ? editableTextBox.getText() : null;
     }
@@ -1170,6 +1174,13 @@ public class CustomListBox extends HorizontalPanel implements ChangeListener, Po
       editableTextBox.setText( text );
       selectedIndex = -1;
       this.onChange( editableTextBox );
+    } else {
+      for( int i = 0; i < items.size(); i++ ) {
+        if( items.get( i ).getText().equals( text ) ) {
+          setSelectedIndex( i );
+          return;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Fix included allowing get and set value to work for non-editable
comboboxes. there really was no reason for those to not return/set the
selected value string.
