### PR TITLE
BACKLOG-306 - CLONE - Exactly matches filters are showing as "EQUAL" and...

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
@@ -2303,7 +2303,7 @@ body.IE>table {
 }
 
 .tundra .dijitArrowButtonInner {
-  background:url("images/16x16_down.png") no-repeat scroll 3px center;
+  background:url("images/16x16_down.png") no-repeat scroll 0px center;
   width: 16px;
   height: 16px;
   margin: 0;

--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/onyx/globalOnyx.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/onyx/globalOnyx.css
@@ -2108,7 +2108,7 @@ div.listbox .pentaho-listbox {
   background:url("../images/comboArrow.png") no-repeat scroll 0 center;
   width: 16px;
   height: 16px;
-  /*margin: 0 4px 0 4px;*/
+  border: 0px;
 }
 .dialog-content .dijitComboBox .dijitArrowButton {
   /* fallback color */


### PR DESCRIPTION
... the filter dropdown is not shown

Fixed width of drop-down list button (with arrow)

Related pull request https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/311
