### PR TITLE
[BACKLOG-3505] In Blockout Times table Repeats End By section is not …

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/mantle/client/workspace/BlockoutPanel.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/mantle/client/workspace/BlockoutPanel.java
@@ -338,11 +338,8 @@ public class BlockoutPanel extends SimplePanel {
         row++;
       }
       table.populateTable( tableContent );
-      table.addStyleName( "" );
       table.setVisible( jobList.size() > 0 );
-
     }
-
   }
 
   private native JsArray<JsJob> parseJson( String json )
@@ -424,7 +421,7 @@ public class BlockoutPanel extends SimplePanel {
     try {
       Date endTime = block.getJobTrigger().getEndTime();
       if ( endTime == null ) {
-        return "Never";
+        return Messages.getString("never");
       } else {
         return formatDate( endTime );
       }


### PR DESCRIPTION
…localized

What was done:
- Read "Never" from properties
- Deleted table.addStyleName( "" ); to fix following error in java script browser console: Uncaught java.lang.IllegalArgumentException: Style names cannot be empty

@kcruzada @dkincade please review