### PR TITLE
[BACKLOG-4844] Fix css with border-radius for date-picker components

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
@@ -5287,7 +5287,7 @@ div.dijitDateTextBox.dijitComboBox .dijitArrowButton {
   box-shadow: none;
 }
 
-#date-picker-dlg-wrapper .dijitComboBox {
+#date-picker-dlg-wrapper .dijitComboBox, div.dijitDateTextBox.dijitComboBox {
   border-top-right-radius: 0px;
   border-bottom-right-radius: 0px;
 }


### PR DESCRIPTION
now date-picker represented without border-radius for crystal.

@plagoa @diogofscmariano @rfellows @krivera-pentaho @scottyaslan @pamval please review