### PR TITLE
[SP-2384] Backport of PPP-3455 - Dynamic code injection vulnerabilities found (5.4 Suite)

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
@@ -880,7 +880,7 @@ public class ScheduleRecurrenceDialog extends AbstractWizardDialog {
       if (null == json || "" == json) {
           return null;
       }
-      var obj = JSON.parse(json);
+      var obj = eval('(' + json + ')');
       return obj;
   }-*/;
 

--- a/pentaho-gwt-widgets/src/org/pentaho/mantle/client/workspace/BlockoutPanel.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/mantle/client/workspace/BlockoutPanel.java
@@ -344,7 +344,7 @@ public class BlockoutPanel extends SimplePanel {
 
   private native JsArray<JsJob> parseJson( String json )
   /*-{
-    var obj = JSON.parse(json);
+    var obj = eval('(' + json + ')');
     return obj.job;
   }-*/;
 


### PR DESCRIPTION
[[PPP-3473]](http://jira.pentaho.com/browse/PPP-3473) Remove insecure eval() in gwt-widgets.
Rollback previous PRs: https://github.com/pentaho/pentaho-commons-gwt-modules/pull/339, https://github.com/pentaho/pentaho-commons-gwt-modules/pull/342.
@pamval, @lucboudreau, @mdamour1976 could you please review?