### PR TITLE
[PPP-3455] - Dynamic code injection vulnerabilities found

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
@@ -880,7 +880,7 @@ public class ScheduleRecurrenceDialog extends AbstractWizardDialog {
       if (null == json || "" == json) {
           return null;
       }
-      var obj = eval('(' + json + ')');
+      var obj = JSON.parse(json);
       return obj;
   }-*/;
 

--- a/pentaho-gwt-widgets/src/org/pentaho/mantle/client/workspace/BlockoutPanel.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/mantle/client/workspace/BlockoutPanel.java
@@ -344,7 +344,7 @@ public class BlockoutPanel extends SimplePanel {
 
   private native JsArray<JsJob> parseJson( String json )
   /*-{
-    var obj = eval('(' + json + ')');
+    var obj = JSON.parse(json);
     return obj.job;
   }-*/;
 


### PR DESCRIPTION
- replace `eval()` with `JSON.parse()` when the former is used to create JSON objects from strings

@mdamour1976, @pentaho-nbaker, review it please.
This replacement seems to be safe, as passed parameters are firstly handled by `JsonUtils.escapeJsonForEval()`. Additionally, I re-build the platform locally and saw no errors in console