### PR TITLE
[SP-2547] - Backport of PPP-3455 - Dynamic code injection vulnerabilities found (5.4 Suite)

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
@@ -877,7 +877,7 @@ public class ScheduleRecurrenceDialog extends AbstractWizardDialog {
       if (null == json || "" == json) {
           return null;
       }
-      var obj = eval('(' + json + ')');
+      var obj = JSON.parse(json);
       return obj;
   }-*/;
 

--- a/pentaho-gwt-widgets/src/org/pentaho/mantle/client/workspace/BlockoutPanel.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/mantle/client/workspace/BlockoutPanel.java
@@ -344,7 +344,7 @@ public class BlockoutPanel extends SimplePanel {
 
   private native JsArray<JsJob> parseJson( String json )
   /*-{
-    var obj = eval('(' + json + ')');
+    var obj = JSON.parse(json);
     return obj.job;
   }-*/;
 


### PR DESCRIPTION
- replace `eval()` with `JSON.parse()` when the former is used to create JSON objects from strings
(cherry-picked from commit 19897a0a58c723e57cc594082efe6ed53486de21)

@mdamour1976, @pamval, review it please. This is a backport of https://github.com/pentaho/pentaho-commons-gwt-modules/pull/349  