### PR TITLE
Revert "[BACKLOG-7482] Javascript error occurs on attempt to close report tab…"

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/tabs/PentahoTab.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/tabs/PentahoTab.java
@@ -168,10 +168,6 @@ public class PentahoTab extends SimplePanel {
   }
 
   public static native void fireCloseTab( String frameId ) /*-{
-    try {
-      $wnd.mantle_fireEvent('GenericEvent', {"eventSubType": "tabClosing", "stringParam": frameId});
-    } catch(e) {
-      // in case when mantle handler was added in a window which no longer exists(got unloaded) - IE will throw an exception, ignore it
-    }
+    $wnd.mantle_fireEvent('GenericEvent', {"eventSubType": "tabClosing", "stringParam": frameId});
   }-*/;
 }


### PR DESCRIPTION
Reverts pentaho/pentaho-commons-gwt-modules#369

After these changes(removing handler):
https://github.com/pentaho/pentaho-platform/pull/2873
https://github.com/pentaho/pentaho-platform-plugin-reporting/pull/298

this try/catch is useless.

@tmorgner 
Please review.