### PR TITLE
[BACKLOG-9273] Create a configuration property that controls the show…

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/mantle/public/messages/mantleMessages.properties
+++ b/pentaho-gwt-widgets/src/org/pentaho/mantle/public/messages/mantleMessages.properties
@@ -630,3 +630,4 @@ confirmSwitchTheme.message=Changing your theme will cause you to lose any unsave
 confirmSwitchTheme.ok=Yes, Change Theme
 confirmSwitchTheme.cancel=No
 pasteFilesCommand.accessDenied=Access denied. Please contact your Administrator.
+kettleStatusMenuItem=PDI Status


### PR DESCRIPTION
…/hide of the 'Tools' sub-menu. This sub-menu sould be hidden by default

	- applying new logic that implements the behaviour stated by PO, which is:
		- The menu item will open a new browser tab (not PUC tab) which is a full page view of the status screen as it exists in DI Server 6.1 and before).
		- The PUC page should remain
		- The new browser tab should have a target name so if the user goes to PUC and selects the menu item again, they do not get a 2nd new browser window with the PDI status page. Instead they are taken to the existing page and the page is refreshed.