### PR TITLE
[SP-2888] Backport of BISERVER-12719 - When creating a schedule the dialog window where the type of schedule is selected isn't fully localized (6.1 Suite)

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/ScheduleEmailWizardPanel.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/ScheduleEmailWizardPanel.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.mantle.client.dialogs.scheduling;
@@ -43,8 +43,8 @@ public class ScheduleEmailWizardPanel extends AbstractWizardPanel {
 
   private static final String PENTAHO_SCHEDULE = "pentaho-schedule-create"; //$NON-NLS-1$
 
-  protected RadioButton yes = new RadioButton( "SCH_EMAIL_YESNO", "Yes" );
-  protected RadioButton no = new RadioButton( "SCH_EMAIL_YESNO", "No" );
+  protected RadioButton yes = new RadioButton( "SCH_EMAIL_YESNO", Messages.getString( "yes" ) );
+  protected RadioButton no = new RadioButton( "SCH_EMAIL_YESNO", Messages.getString( "no" ) );
   protected TextBox toAddressTextBox = new TextBox();
   protected TextBox subjectTextBox = new TextBox();
   protected TextBox attachmentNameTextBox = new TextBox();

--- a/pentaho-gwt-widgets/src/org/pentaho/mantle/public/messages/mantleMessages.properties
+++ b/pentaho-gwt-widgets/src/org/pentaho/mantle/public/messages/mantleMessages.properties
@@ -630,3 +630,4 @@ confirmSwitchTheme.message=Changing your theme will cause you to lose any unsave
 confirmSwitchTheme.ok=Yes, Change Theme
 confirmSwitchTheme.cancel=No
 pasteFilesCommand.accessDenied=Access denied. Please contact your Administrator.
+blocked=Blocked


### PR DESCRIPTION
- backported
@rmansoor 
@pentaho-nbaker
Local tests passed. Wingman lie.
![image](https://cloud.githubusercontent.com/assets/5530292/18250923/2e27cff6-7397-11e6-812c-6b3f2792d75a.png)
