### PR TITLE
[BISERVER-12730] L10N - Untranslated strings in Blockout time table

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/ScheduleEditor.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/ScheduleEditor.java
@@ -819,7 +819,7 @@ public class ScheduleEditor extends VerticalPanel implements IChangeHandler {
         String[] times = startTime.split( ":" ); //$NON-NLS-1$
         int hour = Integer.parseInt( times[0] );
         int minute = Integer.parseInt( times[1] );
-        if ( startTime.indexOf( "PM" ) >= 0 ) { //$NON-NLS-1$
+        if ( startTime.indexOf( TimeOfDay.PM.toString() ) >= 0 ) { //$NON-NLS-1$
           hour += 12;
         }
 

--- a/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
@@ -1009,7 +1009,7 @@ public class ScheduleRecurrenceDialog extends AbstractWizardDialog {
     if ( startTime == null || startTime.length() < 1 ) {
       return 0;
     }
-    int afternoonOffset = startTime.endsWith( "PM" ) ? 12 : 0; //$NON-NLS-1$
+    int afternoonOffset = startTime.endsWith( TimeUtil.TimeOfDay.PM.toString() ) ? 12 : 0; //$NON-NLS-1$
     int hour = Integer.parseInt( startTime.substring( 0, startTime.indexOf( ':' ) ) );
     hour += afternoonOffset;
     return hour;

--- a/pentaho-gwt-widgets/test-src/org/pentaho/mantle/client/dialogs/scheduling/ScheduleEditorTest.java
+++ b/pentaho-gwt-widgets/test-src/org/pentaho/mantle/client/dialogs/scheduling/ScheduleEditorTest.java
@@ -319,7 +319,7 @@ public class ScheduleEditorTest {
     Calendar calendarRequest = Calendar.getInstance();
     calendarRequest.setTime( date );
     when( scheduleEditor.runOnceEditor.getStartDate() ).thenReturn( calendarRequest.getTime() );
-    when( scheduleEditor.runOnceEditor.getStartTime() ).thenReturn( "2:50:33 PM" );
+    when( scheduleEditor.runOnceEditor.getStartTime() ).thenReturn( "2:50:33 " + TimeUtil.TimeOfDay.PM.toString() );
     when( scheduleEditor.getScheduleType() ).thenReturn( ScheduleEditor.ScheduleType.RUN_ONCE );
     final Date startDate = scheduleEditor.getStartDate();
     Calendar calendarResponse = Calendar.getInstance();


### PR DESCRIPTION
- fixed non-localized datetime parsing
- fixed unit-test