### PR TITLE
[BACKLOG-11572] "Edit schedule" dialog is malformed in Japanese local…

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.mantle.client.dialogs.scheduling;
@@ -77,6 +77,8 @@ import com.google.gwt.user.client.ui.Widget;
  *
  */
 public class ScheduleRecurrenceDialog extends AbstractWizardDialog {
+
+  private static final String HOUR_MINUTE_SECOND = "h:mm:ss a";
 
   private final String moduleBaseURL = GWT.getModuleBaseURL();
   private final String moduleName = GWT.getModuleName();
@@ -285,7 +287,7 @@ public class ScheduleRecurrenceDialog extends AbstractWizardDialog {
         }
       }
       scheduleEditor.setStartDate( jsJobTrigger.getStartTime() );
-      scheduleEditor.setStartTime( DateTimeFormat.getFormat( PredefinedFormat.HOUR_MINUTE_SECOND ).format(
+      scheduleEditor.setStartTime( DateTimeFormat.getFormat( HOUR_MINUTE_SECOND ).format(
           jsJobTrigger.getStartTime() ) );
       if ( jsJobTrigger.getEndTime() == null ) {
         scheduleEditor.setNoEndDate();


### PR DESCRIPTION
…ization in PUC

- replaced locale-sensitive formatter pattern with a constant one