### PR TITLE
[BACKLOG-11988] - Reverting e91f46299d69c40e53bbd2d386d15ed3408bdb83 …

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
@@ -577,8 +577,6 @@ For IE 9 and IE10, need to add padding to the bottom of some dialogs generated w
   font-family: OpenSansLight;
   color: #333;
   text-align: center;
-  float: left;
-  width: 100%;
   padding-bottom: 20px;
 }
 
@@ -606,7 +604,6 @@ For IE 9 and IE10, need to add padding to the bottom of some dialogs generated w
   padding: 0;
   width: 100%;
   height: auto;
-  float: left;
 }
 
 .pentaho-dialog .dialog-content {
@@ -4711,10 +4708,6 @@ span.gwt-RadioButton label {
 
 #standardDialog #dialogMessageBar .dlgInfo {
   background: url(images/info.png) no-repeat;
-}
-
-#standardDialog {
-  float: left;
 }
 
 /* Analyzer drag and drop indicators */


### PR DESCRIPTION
…because it is creating problems with dialogs content positions

@pminutillo had to remove this because a lot of dialogs were having issues with this commit. The classes you changed are way to general to put those width 100%. I tried to reproduce the issue you fixed with these changes but it isnt there after removing this commit. Can you give me an hand here?