### PR TITLE
[BACKLOG-8759] Added colons to property labels in themes: crystal, onyx

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
@@ -112,7 +112,7 @@ input[type='text'], .bootstrap .pentaho-dialog input[type='text'] {
 
 input[type='text']#paramNameTextBox,
 input[type='text']#paramValueTextBox {
-  height: 20px;  
+  height: 20px;
 }
 
 SELECT,
@@ -2814,7 +2814,7 @@ padding: 10px 0 10px 0;
 .icon-medium.icon-edit.disabled {
   background: url('../images/editContent_32_disabled.png');
 }
-  /* added by brett to override anlyzer styles */
+  /* added by brett to override analyzer styles */
 .dijitTitlePane{
   background-color: #f1f1f1;
 }
@@ -4767,7 +4767,7 @@ div.listbox .pentaho-listbox {
   height: 22px;
 }
 
-/* layout anel gem styling */
+/* layout panel gem styling */
 .gem{
   height: 17px;
   border-radius: 0px;
@@ -5556,3 +5556,10 @@ treecontrol.tree-classic li .tree-selected {
 }
 
 /* end styling for formatCombo */
+
+/* begin BACKLOG-8759 Makes usage of colons in property labels theme dependent */
+.pentahoPropertiesPanel .dijitTitlePane:last-child .caption-text::after{
+  /* the labels of properties that have dropdowns should have a colon */
+  content: ":";
+}
+/* end BACKLOG-8759 Makes usage of colons in property labels theme dependent */

--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/onyx/globalOnyx.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/onyx/globalOnyx.css
@@ -59,7 +59,7 @@ input[type='text'], .bootstrap .pentaho-dialog input[type='text'] {
 
 input[type='text']#paramNameTextBox,
 input[type='text']#paramValueTextBox {
-  height: 20px;  
+  height: 20px;
 }
 
 *:focus {outline: none;}
@@ -3806,3 +3806,10 @@ treecontrol.tree-classic li .tree-selected {
   border: none;
 }
 /* end styling for formatCombo */
+
+/* begin BACKLOG-8759 Makes usage of colons in property labels theme dependent */
+.pentahoPropertiesPanel .dijitTitlePane:last-child .caption-text::after{
+    /* the labels of properties that have dropdowns should have a colon */
+    content: ":";
+}
+/* end BACKLOG-8759 Makes usage of colons in property labels theme dependent */


### PR DESCRIPTION
@pentaho/millenniumfalcon please review
@DFieldFL please review

The property labels are now defined in their bundles without colons. Colons are now theme-dependent, and are added via a CSS rule.