### PR TITLE
[BACKLOG-11910] fix to shift up 'Resize Panels' button for safari

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
@@ -3593,6 +3593,7 @@ div.dijitDateTextBox.dijitComboBox .dijitArrowButton input[type='text'] {
 
 #tab-dashboard-settings-panel div.panelContent button {
   padding: 6px 14px;
+  margin-top: -3px;
 }
 
 .edit-panel {


### PR DESCRIPTION
@bmorrise 