### PR TITLE
BACKLOG-11894--Combo-box on IE misses the corners of the box (new theme

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
@@ -7512,3 +7512,7 @@ body.bootstrap .modal.confirmationDialog .dialog div.body {
   color: #333;
   padding-bottom: 20px;
 }
+
+.IE11 table.dijitSelect.dijitDownArrowButton td.dijitButtonContents, .IE11 table.dijitSelect.dijitDownArrowButton td.dijitArrowButton {
+  background: transparent;
+}


### PR DESCRIPTION
Sapphire) - IE Only

What was done:
fixed dropdown widget for IE