### PR TITLE
[PPP-3619] Schedules shows wrong "Next run" time/date after schedule was edited.

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/validators/DateRangeEditorValidator.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/validators/DateRangeEditorValidator.java
@@ -12,12 +12,15 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.mantle.client.dialogs.scheduling.validators;
 
+import com.google.gwt.user.datepicker.client.CalendarUtil;
 import org.pentaho.gwt.widgets.client.controls.DateRangeEditor;
+
+import java.util.Date;
 
 public class DateRangeEditorValidator implements IUiValidator {
 
@@ -32,6 +35,10 @@ public class DateRangeEditorValidator implements IUiValidator {
 
     if ( null == dateRangeEditor.getStartDate() ) {
       isValid = false;
+    } else {
+      if ( CalendarUtil.getDaysBetween( new Date(), dateRangeEditor.getStartDate() ) < 0 ) {
+        isValid = false;
+      }
     }
 
     if ( dateRangeEditor.isEndBy() && ( null == dateRangeEditor.getEndDate() ) ) {

--- a/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/validators/RecurrenceEditorValidator.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/validators/RecurrenceEditorValidator.java
@@ -12,11 +12,12 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.mantle.client.dialogs.scheduling.validators;
 
+import com.google.gwt.i18n.client.DateTimeFormat;
 import org.pentaho.gwt.widgets.client.utils.StringUtils;
 import org.pentaho.gwt.widgets.client.utils.TimeUtil;
 import org.pentaho.mantle.client.dialogs.scheduling.RecurrenceEditor;
@@ -26,6 +27,8 @@ import org.pentaho.mantle.client.dialogs.scheduling.RecurrenceEditor.MinutelyRec
 import org.pentaho.mantle.client.dialogs.scheduling.RecurrenceEditor.MonthlyRecurrenceEditor;
 import org.pentaho.mantle.client.dialogs.scheduling.RecurrenceEditor.WeeklyRecurrenceEditor;
 import org.pentaho.mantle.client.dialogs.scheduling.RecurrenceEditor.YearlyRecurrenceEditor;
+
+import java.util.Date;
 
 /**
  * 
@@ -111,6 +114,19 @@ public class RecurrenceEditorValidator implements IUiValidator {
       default:
     }
     isValid &= dateRangeEditorValidator.isValid();
+
+    if ( recurrenceEditor.getStartDate() == null || recurrenceEditor.getStartTime() == null ) {
+      isValid = false;
+    } else {
+      final DateTimeFormat format = DateTimeFormat.getFormat( "MM-dd-yyyy" ); //$NON-NLS-1$
+      final String date = format.format( recurrenceEditor.getStartDate() );
+      final String dateTime = date + " " + recurrenceEditor.getStartTime(); //$NON-NLS-1$
+
+      if ( DateTimeFormat.getFormat( "MM-dd-yyyy hh:mm:ss a" ).parse( dateTime ).before( new Date() ) ) { //$NON-NLS-1$
+        isValid = false;
+      }
+    }
+
     return isValid;
   }
 

--- a/pentaho-gwt-widgets/test-src/org/pentaho/mantle/client/dialogs/scheduling/validators/RecurrenceEditorValidatorTest.java
+++ b/pentaho-gwt-widgets/test-src/org/pentaho/mantle/client/dialogs/scheduling/validators/RecurrenceEditorValidatorTest.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
 */
 
 package org.pentaho.mantle.client.dialogs.scheduling.validators;
@@ -23,6 +23,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pentaho.gwt.widgets.client.utils.TimeUtil;
 import org.pentaho.mantle.client.dialogs.scheduling.RecurrenceEditor;
+
+import java.util.Date;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -37,6 +39,8 @@ public class RecurrenceEditorValidatorTest {
     recurrenceEditor = mock( RecurrenceEditor.class );
     validator = new RecurrenceEditorValidator( recurrenceEditor );
     validator.dateRangeEditorValidator = mock( DateRangeEditorValidator.class );
+    when( recurrenceEditor.getStartDate() ).thenReturn( new Date( System.currentTimeMillis() + 86400000 ) );
+    when( recurrenceEditor.getStartTime() ).thenReturn( "7:12:28 PM" );
   }
 
   @Test


### PR DESCRIPTION
Scheduling in the past is forbidden now.