### PR TITLE
[BACKLOG-11986] Analyzer: Hyperlink menu with incorrect spacing --min…

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
@@ -627,6 +627,13 @@ input#AL_fileLabel {
   width: 335px;
 }
 
+input#AL_filePicker {
+  height: 33px;
+  padding-top: 0;
+  padding-bottom: 0;
+  vertical-align: top;
+}
+
 td.valueCell input[type="text"] {
   width: 320px;
   margin-left: 3px;


### PR DESCRIPTION
…or change

While dev validating the prior PR for bug 11986 (https://github.com/pentaho/pentaho-commons-gwt-modules/pull/529), I noticed another small issue and this PR addresses it...

@bmorrise @DFieldFL  :)