### PR TITLE
[PPP-3619] Schedules shows wrong "Next run" time/date after schedule was edited.

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
@@ -217,6 +217,8 @@ public class ScheduleRecurrenceDialog extends AbstractWizardDialog {
     //setHeight("100%"); //$NON-NLS-1$
     setSize( "650px", "450px" );
     addStyleName( "schedule-recurrence-dialog" );
+
+    updateGUI( getIndex() );
   }
 
   private void setupExisting( JsJob jsJob ) {


### PR DESCRIPTION
 Fixed regression with "Next" button which was not grayed out after the dialog initialization if this was needed.