### PR TITLE
[BACKLOG-15321] Sapphire: PIR toolbar with wrong styling

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
@@ -2770,12 +2770,16 @@ body.IE>table {
 }
 
 .tundra .dijitArrowButtonInner {
-  background: url('images/arrow_down_gray.svg') no-repeat;
-  background-size: 12px 12px;
-  background-position: 1px center !important;
+  background: url("images/16x16_down.png") no-repeat scroll 0px center;
   width: 16px;
   height: 16px;
   margin: 0;
+}
+
+#measure-properties-dialog .dijitArrowButtonInner {
+  background: url('images/arrow_down_gray.svg') no-repeat;
+  background-size: 12px 12px;
+  background-position: 1px center;
 }
 
 .IE .dialog-content .dijitComboBox .dijitArrowButton {


### PR DESCRIPTION
@DFieldFL 

found something that https://github.com/pentaho/pentaho-commons-gwt-modules/pull/549 effected. Here is a fix that handles both problems. Slack me if questions.