### PR TITLE
[BACKLOG-15593] Fixed height of select box for Sapphire theme

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
@@ -192,6 +192,10 @@ SELECT,
   box-sizing: border-box;
 }
 
+SELECT[size] {
+  height: auto;
+}
+
 form SELECT {
   padding: 0 5px;
 }


### PR DESCRIPTION
The height was overridden by https://github.com/annapopova1/pentaho-commons-gwt-modules/blob/bc61f8cb6a28d964ca49d66a65d6f12b75cf98e7/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css#L181 which is used for drop down sapphire theme.
To fix it I use `size` attribute in css to override this height value.
@pentaho/bobafett please review