### PR TITLE
[BACKLOG-15611] - Fix styling for Analyzer chart selection buttons on both themes

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright 2005 - 2010 Pentaho Corporation.  All rights reserved.
+* Copyright 2005 - 2017 Pentaho Corporation.  All rights reserved.
 */
 @font-face {
   font-family: 'OpenSansRegular';
@@ -3214,14 +3214,24 @@ button.adminButton {
 .pc_pageTotal, .dijitToolbar .pc_pageTotal{
   padding: 4px 0px 0px 2px;
 }
-
-.reportArea #selectionFilterPanel{
-  padding: 1px 3px 8px 3px;
-  background-color: #8ab3c6;
-  border-left: 1px #cbdde8 solid;
-  border-right: 1px #cbdde8 solid;
-  border-bottom: 1px #cbdde8 solid;
+/*Overrides Analyzer styles for filter panels*/
+.reportArea #selectionFilterPanel {
+  margin-top: 2px;
+  padding: 0 1px 3px 0;
+  -webkit-box-shadow: 0 4px 2px 0 rgba(0, 0, 0, 0.3);
+  -moz-box-shadow: 0 4px 2px 0 rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 2px 0 rgba(0, 0, 0, 0.3);
+  background-color: transparent;
+  border-left: none;
+  border-right: none;
+  border-bottom: none;
   opacity: 1;
+}
+/*Overrides pentaho button styles just for analyzer*/
+.reportArea #selectionFilterPanel > .btnContainer > button {
+  -webkit-box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.3);
+  -moz-box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.3);
+  box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.3);
 }
 /* added by brett to for PIR  */
 #formattabpanelinner .tundra .dijitToolbar {

--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright 2005 - 2010 Pentaho Corporation.  All rights reserved.
+* Copyright 2005 - 2017 Pentaho Corporation.  All rights reserved.
 */
 @font-face {
   font-family: 'OpenSansRegular';
@@ -4256,13 +4256,14 @@ button.adminButton {
 .dijitToolbar .pc_pageTotal {
   padding: 4px 0px 0px 2px;
 }
-
+/*Overrides Analyzer styles for filter panels*/
 .reportArea #selectionFilterPanel {
-  padding: 1px 3px 8px 3px;
-  background-color: #8ab3c6;
-  border-left: 1px #CCC solid;
-  border-right: 1px #CCC solid;
-  border-bottom: 1px #CCC solid;
+  margin-top: 2px;
+  padding: 1px 3px 11px 3px;
+  background-color: transparent;
+  border-left: none;
+  border-right: none;
+  border-bottom: none;
   opacity: 1;
 }
 


### PR DESCRIPTION
* For sapphire the panel was incremented to avoid cutting and the background was made transparent
* For crystal the shadow of the buttons was override and a shadow was added in the container 