### PR TITLE
[BACKLOG-15589] - In Firefox, PUC Open dialog, location dropdown button does not have normal size in both crystal and saphire themes

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
@@ -190,6 +190,15 @@ SELECT,
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: url(images/arrow_down_gray.svg) no-repeat;
+  background-size: 12px 12px;
+  background-position: right 8px center
+}
+SELECT::-ms-expand {
+  display: none; /*hides dropdown arrow in IE*/
 }
 
 SELECT[size] {


### PR DESCRIPTION
* override browser default arrow style for sapphire
* for crystal the button has the correct size so no modification is made