### PR TITLE
[BACKLOG-15537] - Sapphire - Dashboard Designer - Apply and Resize Panels buttons are cut

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
@@ -3972,10 +3972,6 @@ div.dijitDateTextBox.dijitComboBox {
   border: 0;
 }
 
-#tab-dashboard-settings-panel div.panelContent {
-  overflow: hidden;
-}
-
 #tab-dashboard-settings-panel div.panelContent button {
   padding: 6px 14px;
   margin-top: -3px;


### PR DESCRIPTION
* eliminating override of overflow in settings panel, so the overflow should now appear when necessary
* merge after: https://github.com/pentaho/pentaho-platform-plugin-dashboards/pull/370