### PR TITLE
[BISERVER-12677]-Session expired dialog

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/dialogs/SessionExpiredDialog.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/dialogs/SessionExpiredDialog.java
@@ -1,0 +1,58 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2017 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.gwt.widgets.client.dialogs;
+
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import org.pentaho.gwt.widgets.client.messages.Messages;
+
+
+public class SessionExpiredDialog extends PromptDialogBox {
+
+  public SessionExpiredDialog() {
+    super( Messages.getString( "dialog.sessionExpired.title" ), Messages.getString( "dialog.button.ok" ), null,
+      Messages.getString( "dialog.sessionExpired.close" ), false, true );
+    this.okButton.setVisible( false );
+    final VerticalPanel content = new VerticalPanel();
+    final Label contentString = new Label( Messages.getString( "dialog.sessionExpired.content" ) );
+    content.add( contentString );
+    setContent( content );
+    setCallback( new SessionExpiredDialogCallback() );
+  }
+
+  private class SessionExpiredDialogCallback implements IDialogCallback {
+
+    @Override public void okPressed() {
+      //OK button is always hidden
+    }
+
+    @Override public void cancelPressed() {
+      redirectToPUCLogin();
+    }
+
+    private void redirectToPUCLogin() {
+      final String[] pathArray = Window.Location.getPath().split( "/" );
+      if ( null != pathArray && pathArray.length > 1 ) {
+        Window.Location.assign(  "/" + pathArray[ 1 ] + "/Login"  );
+      }
+    }
+  }
+
+
+}

--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/public/messages/WidgetsMessages.properties
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/public/messages/WidgetsMessages.properties
@@ -8,3 +8,6 @@ DateRangeEditor.rangeOfRecurrence=Range of recurrence
 DateRangeEditor.startLabel=Start:
 DateRangeEditor.noEndDateLabel=No end date
 DateRangeEditor.endByLabel=End by:
+dialog.sessionExpired.close=Close
+dialog.sessionExpired.title=Session Expired
+dialog.sessionExpired.content=You've been logged out due to inactivity. Please login to continue.


### PR DESCRIPTION
A UI for the session expired dialog - http://ux.pentaho.com/puc-session-timeout/#g=1&p=recommendation
Covers a top window with a glass pane, the only button redirects to the login page.
Needed to be merged before https://github.com/pentaho/pentaho-platform/pull/3498



@pamval @mbatchelor @tmorgner 