### PR TITLE
[BISERVER-12677]-SessionExpiredDialog z-index fix

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/dialogs/DialogBox.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/dialogs/DialogBox.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.gwt.widgets.client.dialogs;
@@ -146,4 +146,7 @@ public class DialogBox extends com.google.gwt.user.client.ui.DialogBox implement
     GlassPane.getInstance().hide();
   }
 
+  protected static FocusPanel getPageBackground() {
+    return pageBackground;
+  }
 }

--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/dialogs/SessionExpiredDialog.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/dialogs/SessionExpiredDialog.java
@@ -18,6 +18,7 @@
 package org.pentaho.gwt.widgets.client.dialogs;
 
 import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.FocusPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import org.pentaho.gwt.widgets.client.messages.Messages;
@@ -36,10 +37,19 @@ public class SessionExpiredDialog extends PromptDialogBox {
     setCallback( new SessionExpiredDialogCallback() );
   }
 
+  @Override public void center() {
+    super.center();
+    this.getElement().getStyle().setZIndex( Integer.MAX_VALUE );
+    final FocusPanel background = getPageBackground();
+    if ( background != null ) {
+      background.getElement().getStyle().setZIndex( Integer.MAX_VALUE - 1 );
+    }
+  }
+
   private class SessionExpiredDialogCallback implements IDialogCallback {
 
     @Override public void okPressed() {
-      //OK button is always hidden
+      redirectToPUCLogin();
     }
 
     @Override public void cancelPressed() {
@@ -49,7 +59,7 @@ public class SessionExpiredDialog extends PromptDialogBox {
     private void redirectToPUCLogin() {
       final String[] pathArray = Window.Location.getPath().split( "/" );
       if ( null != pathArray && pathArray.length > 1 ) {
-        Window.Location.assign(  "/" + pathArray[ 1 ] + "/Login"  );
+        Window.Location.assign( "/" + pathArray[ 1 ] + "/Login" );
       }
     }
   }


### PR DESCRIPTION
This will fix a dialog position. Nevertheless, there is an issue with data-access dialogs and wizards, which blocks all the clicks on the page until the dialog is closed.  Most likely should be addressed in the data-access project.

@pamval @mbatchelor @pedrofvteixeira @afrjorge 