### PR TITLE
[SP-3668]: Backport of BISERVER-13603 - IE - PDF pane remains active …

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/dialogs/DialogBox.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/dialogs/DialogBox.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.gwt.widgets.client.dialogs;
@@ -144,6 +144,10 @@ public class DialogBox extends com.google.gwt.user.client.ui.DialogBox implement
 
     // Notify listeners that we're hiding a dialog (re-show PDFs, flash).
     GlassPane.getInstance().hide();
+  }
+
+  protected static FocusPanel getPageBackground() {
+    return pageBackground;
   }
 
 }

--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/dialogs/PromptDialogBox.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/dialogs/PromptDialogBox.java
@@ -12,16 +12,19 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.gwt.widgets.client.dialogs;
 
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.ClickListener;
 import com.google.gwt.user.client.ui.FlexTable;
+import com.google.gwt.user.client.ui.FocusPanel;
 import com.google.gwt.user.client.ui.FocusWidget;
+import com.google.gwt.user.client.ui.Frame;
 import com.google.gwt.user.client.ui.HasHorizontalAlignment;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.HorizontalPanel;
@@ -200,5 +203,28 @@ public class PromptDialogBox extends DialogBox {
     }
     hide();
   }
+
+  @Override
+  public void center() {
+    super.center();
+    if ( isIEBrowser() ) {
+      this.getElement().getStyle().setZIndex( Integer.MAX_VALUE );
+      final FocusPanel background = getPageBackground();
+      if ( background != null ) {
+        background.getElement().getStyle().setZIndex( Integer.MAX_VALUE - 1 );
+        Frame iFrame = new Frame( "about:blank" );
+        Style iFrameStyle = iFrame.getElement().getStyle();
+        iFrameStyle.setWidth( 100, Style.Unit.PCT );
+        iFrameStyle.setHeight( 100, Style.Unit.PCT );
+        iFrameStyle.setBorderStyle( Style.BorderStyle.NONE );
+        background.add( iFrame );
+      }
+    }
+  }
+
+  private native boolean isIEBrowser()
+  /*-{
+    return !!document.documentMode;
+  }-*/;
 
 }


### PR DESCRIPTION
…when glass pane was activated, which blocks user from accepting/declining action in appeared dialog box. (7.1 Suite)

Cherry-pick of the fix for [BISERVER-13603] - IE - PDF pane remains active when glass pane was activated, which blocks user from accepting/declining action in appeared dialog box.
Additional method getPageBackground().