### PR TITLE
[SP-3667] - Backport of BISERVER-13603 - IE - PDF pane remains active…

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/dialogs/PromptDialogBox.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/dialogs/PromptDialogBox.java
@@ -211,7 +211,6 @@ public class PromptDialogBox extends DialogBox {
       this.getElement().getStyle().setZIndex( Integer.MAX_VALUE );
       final FocusPanel background = getPageBackground();
       if ( background != null ) {
-        background.getElement().getStyle().setZIndex( Integer.MAX_VALUE - 1 );
         Frame iFrame = new Frame( "about:blank" );
         Style iFrameStyle = iFrame.getElement().getStyle();
         iFrameStyle.setWidth( 100, Style.Unit.PCT );


### PR DESCRIPTION
… when glass pane was activated, which blocks user from accepting/declining action in appeared dialog box. (6.1 Suite)

 - regression fix

@mbatchelor, could you please take a look?