### PR TITLE
[BISERVER-13603] IE - PDF pane remains active when glass pane was act…

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/dialogs/PromptDialogBox.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/dialogs/PromptDialogBox.java
@@ -221,9 +221,13 @@ public class PromptDialogBox extends DialogBox {
     }
   }
 
-  private native boolean isIEBrowser()
+  private boolean isIEBrowser() {
+    return getUserAgent().contains( "msie" );
+  }
+
+  private static native String getUserAgent()
   /*-{
-    return !!document.documentMode;
+    return navigator.userAgent.toLowerCase();
   }-*/;
 
 }


### PR DESCRIPTION
…ivated, which blocks user from accepting/declining action in appeared dialog box

 - having IE check this way breaks sheduler`s "Execute now" run
 - changed IE check to a most recommended one