### PR TITLE
[BISERVER-12677] Login as another user after PUC session time-out sti…

### DIFF
--- a/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/dialogs/SessionExpiredDialog.java
+++ b/pentaho-gwt-widgets/src/org/pentaho/gwt/widgets/client/dialogs/SessionExpiredDialog.java
@@ -37,13 +37,13 @@ public class SessionExpiredDialog extends PromptDialogBox {
   }
 
   @Override public void center() {
+    super.center();
     this.getElement().getStyle().setZIndex( Integer.MAX_VALUE );
     final FocusPanel background = getPageBackground();
     if ( background != null ) {
       background.getElement().getStyle().setZIndex( Integer.MAX_VALUE - 1 );
     }
     setEventListener( this.cancelButton.getElement() );
-    super.center();
   }
 
   /**


### PR DESCRIPTION
…ll shows previous logged user

 - fixed "invisible glasspane" issue. z-index is now set after initialization