### PR TITLE
[BACKLOG-20385] As a customer using Worker Nodes on Foundry, I would …

### DIFF
--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/NewScheduleDialog.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/NewScheduleDialog.java
@@ -78,6 +78,7 @@ public class NewScheduleDialog extends PromptDialogBox {
   private CheckBox overrideExistingChk = new CheckBox();
   private static HandlerRegistration changeHandlerReg = null;
   private static HandlerRegistration keyHandlerReg = null;
+  private Label runOptionsLabel;
   private CheckBox useWorkerNodesChk = new CheckBox();
 
   static {
@@ -278,9 +279,12 @@ public class NewScheduleDialog extends PromptDialogBox {
       }
     }
 
+    runOptionsLabel = new Label( Messages.getString( "runOptions" ) );
+    runOptionsLabel.setStyleName( ScheduleEditor.SCHEDULE_LABEL );
     useWorkerNodesChk.setText( Messages.getString( "useWorkerNodes" ) ); //$NON-NLS-1$
     useWorkerNodesChk.setValue( ScheduleHelper.DEFAULT_DISTRIBUTE_LOAD_VIA_WORKER_NODES_SETTING );
-    ScheduleHelper.showOptionToDistributeLoadViaWorkerNodes( useWorkerNodesChk );
+    ScheduleHelper.showOptionToDistributeLoadViaWorkerNodes( runOptionsLabel, useWorkerNodesChk );
+    content.add( runOptionsLabel );
     content.add( useWorkerNodesChk );
 
     setContent( content );

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleHelper.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleHelper.java
@@ -276,7 +276,7 @@ public class ScheduleHelper {
     return $wnd.location.protocol + "//" + $wnd.location.host + $wnd.CONTEXT_PATH
   }-*/;
 
-  public static void showOptionToDistributeLoadViaWorkerNodes( final CheckBox useWorkerNodesCheckbox ) {
+  public static void showOptionToDistributeLoadViaWorkerNodes( final Label panelLabel, final CheckBox useWorkerNodesCheckbox ) {
 
     if ( useWorkerNodesCheckbox == null ) {
       return;
@@ -284,6 +284,7 @@ public class ScheduleHelper {
 
     // default is false; only render checkbox if Worker Nodes capability is enabled in the system
     useWorkerNodesCheckbox.setVisible( DEFAULT_DISTRIBUTE_LOAD_VIA_WORKER_NODES_VISIBILITY );
+    panelLabel.setVisible( useWorkerNodesCheckbox.isVisible() );
 
     try {
 
@@ -301,6 +302,9 @@ public class ScheduleHelper {
 
           if ( response != null && response.getStatusCode() == Response.SC_OK ) {
             useWorkerNodesCheckbox.setVisible( Boolean.TRUE.toString().equalsIgnoreCase( response.getText() ) );
+
+            // if the checkbox becomes visible, so should its panel label
+            panelLabel.setVisible( useWorkerNodesCheckbox.isVisible() );
           }
         }
       } );

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleOutputLocationDialog.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleOutputLocationDialog.java
@@ -52,6 +52,7 @@ public abstract class ScheduleOutputLocationDialog extends PromptDialogBox {
   private static TextBox scheduleLocationTextBox = new TextBox();
   private static HandlerRegistration changeHandlerReg = null;
   private static HandlerRegistration keyHandlerReg = null;
+  private Label runOptionsLabel;
   private CheckBox useWorkerNodesChk = new CheckBox();
 
   static {
@@ -143,9 +144,12 @@ public abstract class ScheduleOutputLocationDialog extends PromptDialogBox {
 
     content.add( locationPanel );
 
+    runOptionsLabel = new Label( Messages.getString( "runOptions" ) );
+    runOptionsLabel.setStyleName( ScheduleEditor.SCHEDULE_LABEL );
     useWorkerNodesChk.setText( Messages.getString( "useWorkerNodes" ) ); //$NON-NLS-1$
     useWorkerNodesChk.setValue( ScheduleHelper.DEFAULT_DISTRIBUTE_LOAD_VIA_WORKER_NODES_SETTING );
-    ScheduleHelper.showOptionToDistributeLoadViaWorkerNodes( useWorkerNodesChk );
+    ScheduleHelper.showOptionToDistributeLoadViaWorkerNodes( runOptionsLabel, useWorkerNodesChk );
+    content.add( runOptionsLabel );
     content.add( useWorkerNodesChk );
 
     setContent( content );

--- a/widgets/src/main/resources/org/pentaho/mantle/public/messages/mantleMessages.properties
+++ b/widgets/src/main/resources/org/pentaho/mantle/public/messages/mantleMessages.properties
@@ -433,6 +433,7 @@ scheduleNameColon=Schedule Name:
 scheduleNameInfo=This will also be the name of the generated content.
 appendTimeToName=Append timestamp to generated content
 useWorkerNodes=Use Worker Nodes to distribute processing
+runOptions=Run Options
 overrideExistingFile=Overwrite existing files with same name
 overrideExistingFileAndTime=Overwrite existing files with same name and timestamp
 editSchedule=Edit Schedule


### PR DESCRIPTION
…like to be able to run work items on the Pentaho Server, so that these Work Items run on the Pentaho Server even though we are in Worker Node mode

Added _"Run Options"_ label, as per UX's mockup: http://ux.pentaho.com/puc-run-worker-node/#g=1&p=mockup

@pentaho/rogueone please review