### PR TITLE
[BACKLOG-20385] As a customer using Worker Nodes on Foundry, I would …

### DIFF
--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleHelper.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleHelper.java
@@ -22,6 +22,7 @@ import org.pentaho.gwt.widgets.client.dialogs.IDialogCallback;
 import org.pentaho.gwt.widgets.client.dialogs.MessageDialogBox;
 import org.pentaho.gwt.widgets.client.dialogs.PromptDialogBox;
 import org.pentaho.gwt.widgets.client.filechooser.RepositoryFile;
+import org.pentaho.gwt.widgets.client.utils.NameUtils;
 import org.pentaho.gwt.widgets.client.utils.string.StringUtils;
 import org.pentaho.mantle.client.commands.AbstractCommand;
 import org.pentaho.mantle.client.events.EventBusUtil;
@@ -37,7 +38,6 @@ import com.google.gwt.http.client.RequestCallback;
 import com.google.gwt.http.client.RequestException;
 import com.google.gwt.http.client.Response;
 import com.google.gwt.json.client.JSONString;
-import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.CheckBox;
@@ -291,7 +291,7 @@ public class ScheduleHelper {
 
     try {
 
-      final String url = ScheduleHelper.getFullyQualifiedURL() + IS_FILE_SUPPORTED_IN_WORKER_NODES_URL + SafeHtmlUtils.htmlEscape( filename );
+      final String url = ScheduleHelper.getFullyQualifiedURL() + IS_FILE_SUPPORTED_IN_WORKER_NODES_URL + NameUtils.URLEncode( filename );
 
       RequestBuilder requestBuilder = new RequestBuilder( RequestBuilder.GET, url );
       requestBuilder.setHeader( "accept", "text/plain" );


### PR DESCRIPTION
…like to be able to run work items on the Pentaho Server, so that these Work Items run on the Pentaho Server even though we are in Worker Node mode

- Switching from GWT's `SafeHtmlUtils` to Pentaho's own `NameUtils` for URL encoding the provided filename, as is a better approach.

@pentaho/rogueone please review