### PR TITLE
[BACKLOG-20385] As a customer using Worker Nodes on Foundry, I would …

### DIFF
--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/NewScheduleDialog.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/NewScheduleDialog.java
@@ -280,7 +280,7 @@ public class NewScheduleDialog extends PromptDialogBox {
     }
 
     runOptionsLabel = new Label( Messages.getString( "runOptions" ) );
-    runOptionsLabel.setStyleName( ScheduleEditor.SCHEDULE_LABEL );
+    runOptionsLabel.setStyleName( ScheduleEditor.SECTION_DIVIDER_TITLE_LABEL );
     useWorkerNodesChk.setText( Messages.getString( "useWorkerNodes" ) ); //$NON-NLS-1$
     useWorkerNodesChk.setValue( ScheduleHelper.DEFAULT_DISTRIBUTE_LOAD_VIA_WORKER_NODES_SETTING );
     ScheduleHelper.showOptionToDistributeLoadViaWorkerNodes( runOptionsLabel, useWorkerNodesChk, filePath );

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleEditor.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleEditor.java
@@ -110,6 +110,8 @@ public class ScheduleEditor extends VerticalPanel implements IChangeHandler {
 
   protected static final String SCHEDULE_LABEL = "schedule-label"; //$NON-NLS-1$
 
+  protected static final String SECTION_DIVIDER_TITLE_LABEL = "section-divider-title"; //$NON-NLS-1$
+
   protected static final String SCHEDULE_EDITOR_CAPTION_PANEL = "schedule-editor-caption-panel"; //$NON-NLS-1$
 
   protected static final String BLOCKOUT_SELECT = "blockout-select";

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleEditor.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleEditor.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.mantle.client.dialogs.scheduling;

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleOutputLocationDialog.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleOutputLocationDialog.java
@@ -145,7 +145,7 @@ public abstract class ScheduleOutputLocationDialog extends PromptDialogBox {
     content.add( locationPanel );
 
     runOptionsLabel = new Label( Messages.getString( "runOptions" ) );
-    runOptionsLabel.setStyleName( ScheduleEditor.SCHEDULE_LABEL );
+    runOptionsLabel.setStyleName( ScheduleEditor.SECTION_DIVIDER_TITLE_LABEL );
     useWorkerNodesChk.setText( Messages.getString( "useWorkerNodes" ) ); //$NON-NLS-1$
     useWorkerNodesChk.setValue( ScheduleHelper.DEFAULT_DISTRIBUTE_LOAD_VIA_WORKER_NODES_SETTING );
     ScheduleHelper.showOptionToDistributeLoadViaWorkerNodes( runOptionsLabel, useWorkerNodesChk, filePath );


### PR DESCRIPTION
…like to be able to run work items on the Pentaho Server, so that these Work Items run on the Pentaho Server even though we are in Worker Node mode

- Applying the _"Run Options"_ styling as per defined in the UX mockups at http://ux.pentaho.com/puc-run-worker-node/#g=1&p=mockup

@pentaho/rogueone please review

To be merged alongside https://github.com/pentaho/pentaho-platform/pull/4012