### PR TITLE
[ANALYZER-3641] - Date Picker showing empty

### DIFF
--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright 2005 - 2017 Hitachi Vantara.  All rights reserved.
+* Copyright 2005 - 2018 Hitachi Vantara.  All rights reserved.
 */
 @font-face {
   font-family: 'OpenSansRegular';
@@ -6688,7 +6688,7 @@ div.dijitPopup.dijitCalendarPopup {
 #widget_DP_range1_lookup .dijitArrowButtonInner,
 #widget_DP_range2_lookup .dijitArrowButtonInner,
 div.dijitDateTextBox .dijitArrowButtonInner {
-  background-image: url("images/calendar_icon.png") !important;
+  background-image: url("images/calendar-white.png") !important;
   width: 16px;
 }
 
@@ -6960,6 +6960,21 @@ treecontrol.tree-classic li .tree-selected {
   border-radius: 4px;
   border-left: none;
   width: 22px;
+}
+
+#DP_range1 #widget_DP_range1_lookup,
+#DP_range2 #widget_DP_range2_lookup,
+div.dijitDateTextBox.dijitTextBox .dijitReset.dijitRight.dijitButtonNode.dijitArrowButton.dijitDownArrowButton.dijitArrowButtonContainer {
+  background-color: #005DA6;
+  color: #fff;
+  border-radius: 3px;
+}
+
+#DP_range1 #widget_DP_range1_lookup,
+#DP_range2 #widget_DP_range2_lookup,
+div.dijitDateTextBox.dijitTextBox .dijitReset.dijitRight.dijitButtonNode.dijitArrowButton.dijitDownArrowButton.dijitArrowButtonContainer input {
+  margin: 8px 0 0 3px;
+  background: url(images/calendar-white.png) no-repeat !important;
 }
 
 .tundra .pentahoFormatCombo.dijitComboBox,


### PR DESCRIPTION
* Analyzer's DatePicker changed according to UX recommendations:
- Removed calendar template to simplify the dialog.
- Alligned the labels and widgets to the left.
- Fixed Sapphire's theme display.