### PR TITLE
[ANALYZER-3641] - Date Picker showing empty

### DIFF
--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
@@ -6641,6 +6641,7 @@ div.dijitDateTextBox {
 div.dijitDateTextBox.dijitComboBox .dijitArrowButton {
   border: none;
   box-shadow: none;
+  border-radius: 0 3px 3px 0;
 }
 
 #date-picker-dlg-wrapper .dijitComboBox {


### PR DESCRIPTION
* Removed top and bottom left border-radius on the calendar background, as requested by UX team.