### PR TITLE
[BACKLOG-22937] - When scheduled generated content name doesn't have …

### DIFF
--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/NewScheduleDialog.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/NewScheduleDialog.java
@@ -295,7 +295,16 @@ public class NewScheduleDialog extends PromptDialogBox {
   }
 
   protected void onOk() {
-    String name = scheduleNameTextBox.getText();
+    String name;
+    if ( appendTimeChk.getValue().booleanValue() ) {
+      name = getPreviewName( timestampLB.getSelectedIndex() );
+    } else {
+      //trim the name if there is no timestamp appended
+      scheduleNameTextBox.setText( scheduleNameTextBox.getText().trim() );
+
+      name = scheduleNameTextBox.getText();
+    }
+
     if ( !NameUtils.isValidFileName( name ) ) {
       MessageDialogBox errorDialog =
           new MessageDialogBox( Messages.getString( "error" ), Messages.getString( "prohibitedNameSymbols", name,

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleOutputLocationDialog.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleOutputLocationDialog.java
@@ -234,7 +234,16 @@ public abstract class ScheduleOutputLocationDialog extends PromptDialogBox {
     setValidatorCallback( new IDialogValidatorCallback() {
       @Override
       public boolean validate() {
-        String name = scheduleNameTextBox.getText();
+        String name;
+        if ( appendTimeChk.getValue().booleanValue() ) {
+          name = getPreviewName( timestampLB.getSelectedIndex() );
+        } else {
+          //trim the name if there is no timestamp appended
+          scheduleNameTextBox.setText( scheduleNameTextBox.getText().trim() );
+
+          name = scheduleNameTextBox.getText();
+        }
+
         boolean isValid = NameUtils.isValidFileName( name );
         if ( !isValid ) {
           MessageDialogBox errorDialog =


### PR DESCRIPTION
[BACKLOG-22937] - When scheduled generated content name doesn't have a timestamp appended - trim,otherwise validate full generated content name with timestamp