### PR TITLE
[BACKLOG-26242] PUC - Error creating a New Schedule

### DIFF
--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleParamsDialog.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleParamsDialog.java
@@ -340,7 +340,7 @@ public class ScheduleParamsDialog extends AbstractWizardDialog {
   public void center() {
     if ( scheduleParams != null ) {
       // we have saved params from back/next
-      String urlPath = NameUtils.encodeRepositoryPath( filePath );
+      String urlPath = URL.encodePathSegment( NameUtils.encodeRepositoryPath( filePath ) );
       String urlParams = "";
       for ( int i = 0; i < scheduleParams.size(); i++ ) {
         JSONObject o = scheduleParams.get( i ).isObject();
@@ -351,7 +351,8 @@ public class ScheduleParamsDialog extends AbstractWizardDialog {
         for ( int j = 0; j < stringValueArr.size(); j++ ) {
           urlParams += ( i == 0 && j == 0 ) ? "?" : "&";
           urlParams +=
-              name.stringValue().replace( "\"", "" ) + "=" + stringValueArr.get( j ).toString().replace( "\"", "" );
+              name.stringValue().replace( "\"", "" )
+                      + "=" +  URL.encodeQueryString( stringValueArr.get( j ).toString().replace( "\"", "" ) );
         }
       }
       setParametersUrl( ScheduleHelper.getFullyQualifiedURL() + "api/repos/" + urlPath + "/parameterUi" + urlParams ); //$NON-NLS-1$ //$NON-NLS-2$


### PR DESCRIPTION
Added code to encode urlPath and queryString when going `Back -> Next` from `parameters` page to `schedule` page on `New Schedule Dialog`

`api/repos/:public:Steel%20Wheels:Top%20Customers%20(report).prpt/parameterUi?sLine=[Product].[All%20Products].[Classic%20Cars]` becomes `api/repos/%3Apublic%3ASteel%20Wheels%3ATop%20Customers%20(report).prpt/parameterUi?sLine=%5BProduct%5D.%5BAll+Products%5D.%5BClassic+Cars%5D`

@pentaho/rogueone 