### PR TITLE
[SP-4800] Backport for BACKLOG-26741 -- 8.2 Carte status page unable to acess Scaleable Vector Graphic (.svg) files

### DIFF
--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/images/run_option.svg
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/images/run_option.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 22 22" style="enable-background:new 0 0 22 22;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#414242;}
+</style>
+<title>run</title>
+<path class="st0" d="M0,19l15.7-8L0,3V19z M1.6,5.6L12.1,11L1.6,16.4V5.6z"/>
+<g id="Layer_2_1_">
+	<g>
+		<g>
+			<polygon class="st0" points="17.1,10.4 19.3,12.6 21.5,10.4 22,10.9 19.3,13.6 16.6,10.9 			"/>
+		</g>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
…ver status page

This is part of one of the commits for https://github.com/pentaho/pentaho-kettle/pull/6082