### PR TITLE
[SP-5357] Backport of ANALYZER-3904 - Analyzer's Save and Save As dialog are querying entire tree list of files and folders when using showRepositoryButtons=true on iFrame (8.3 Suite)

### DIFF
--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/filechooser/FileChooserEntryPoint.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/filechooser/FileChooserEntryPoint.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2019 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2020 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.gwt.widgets.client.filechooser;

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/filechooser/FileChooserEntryPoint.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/filechooser/FileChooserEntryPoint.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2019 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.gwt.widgets.client.filechooser;
@@ -104,13 +104,28 @@ public class FileChooserEntryPoint implements EntryPoint, IResourceBundleLoadCal
   }
 
   public void saveFileChooserDialog( final JavaScriptObject callback, String selectedPath ) {
-    FileChooserDialog dialog = new FileChooserDialog( FileChooserMode.SAVE, selectedPath, false, true );
+    FileChooserDialog dialog = null;
+    if (selectedPath == null) {
+      // Loads whole repository from top level
+      dialog = new FileChooserDialog( FileChooserMode.SAVE, selectedPath, false, true );
+    } else {
+      // Loads repository just at the selectedPath
+      dialog = new FileChooserDialog( FileChooserMode.SAVE, selectedPath, null, false, true );
+    }
     addFileChooserListener( dialog, callback );
   }
 
   public void saveAsFileChooserDialog( final JavaScriptObject callback, String selectedPath ) {
-    FileChooserDialog dialog = new FileChooserDialog( FileChooserMode.SAVE, selectedPath, false, true,
-        messages.getString( "SaveAs" ), messages.getString( "Save" ) );
+    FileChooserDialog dialog = null;
+    if (selectedPath == null) {
+      // Loads whole repository from top level
+      dialog = new FileChooserDialog( FileChooserMode.SAVE, selectedPath, false, true,
+          messages.getString( "SaveAs" ), messages.getString( "Save" ) );
+    } else {
+      // Loads repository just at the selectedPath
+      dialog = new FileChooserDialog( FileChooserMode.SAVE, selectedPath, null, false, true,
+          messages.getString( "SaveAs" ), messages.getString( "Save" ) );
+    }
     addFileChooserListener( dialog, callback );
   }
 


### PR DESCRIPTION
**Attention: This is the outcome of an automated process!**
Merge Masters: @ppatricio and @bcostahitachivantara
Cherry-picks:
* https://github.com/Pentaho/pentaho-commons-gwt-modules/commit/24d191f056c7b329522c3c0a05228054bdb65c63
