### PR TITLE
[SP-5357] Backport of BACKLOG-32839 Fix SaveAs dialog's file tree not refreshing after a …

### DIFF
--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/filechooser/FileChooser.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/filechooser/FileChooser.java
@@ -12,9 +12,8 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2019 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002 - 2020 Hitachi Vantara..  All rights reserved.
  */
-
 package org.pentaho.gwt.widgets.client.filechooser;
 
 import com.google.gwt.core.client.GWT;
@@ -93,7 +92,8 @@ public class FileChooser extends VerticalPanel {
 
   public FileChooser() {
     super();
-    fileNameTextBox.getElement().setId( "fileNameTextBox" ); //$NON-NLS-1$
+
+    fileNameTextBox.getElement().setId( "fileNameTextBox" );
 
     // workaround webkit browsers quirk of not being able to set focus in a widget by clicking on it
     fileNameTextBox.addClickHandler( new ClickHandler() {
@@ -114,11 +114,13 @@ public class FileChooser extends VerticalPanel {
         }
       }
     } );
+
     setSpacing( 3 );
   }
 
   public FileChooser( boolean showHiddenFiles ) {
     this();
+
     this.showHiddenFiles = showHiddenFiles;
   }
 
@@ -128,6 +130,7 @@ public class FileChooser extends VerticalPanel {
       if ( file != null && !file.isFolder() && file.getPath().equals( actualFileName ) ) {
         return file;
       }
+
       if ( file != null ) {
         for ( RepositoryFileTree treeItem : tree.getChildren() ) {
           file = search( treeItem, actualFileName );
@@ -137,8 +140,9 @@ public class FileChooser extends VerticalPanel {
         }
       }
     } catch ( Exception e ) {
-      return null;
+      // does nothing
     }
+
     return null;
   }
 
@@ -149,10 +153,12 @@ public class FileChooser extends VerticalPanel {
   public FileChooser( FileChooserMode mode, String selectedPath, boolean showLocalizedFileNames,
                       RepositoryFileTree fileTree ) {
     this();
+
     this.mode = mode;
     this.selectedPath = selectedPath;
     this.fileTree = fileTree;
     this.showLocalizedFileNames = showLocalizedFileNames;
+
     if ( null != fileTree ) {
       repositoryTree = TreeBuilder.buildSolutionTree( fileTree, showHiddenFiles, showLocalizedFileNames, fileFilter );
       selectedTreeItem = repositoryTree.getItem( 0 );
@@ -162,8 +168,10 @@ public class FileChooser extends VerticalPanel {
 
   public FileChooser( FileChooserMode mode, String selectedPath, IDialogCallback callback ) {
     this();
+
     this.mode = mode;
     this.selectedPath = selectedPath;
+
     try {
       fetchRepository( callback );
     } catch ( RequestException e ) {
@@ -198,21 +206,26 @@ public class FileChooser extends VerticalPanel {
    * Take the loaded RepositoryFileTree and insert it into the file structure RepositoryFileTree
    *
    * @param loadedTree
-   * @param cacheN
+   * @param cache
    */
   private void buildTree( RepositoryFileTree loadedTree, boolean cache ) {
+    final String loadedFilePath = loadedTree.getFile().getPath();
     if ( cache ) {
-      lazyTreeLoader.cache( loadedTree.getFile().getPath(), loadedTree );
+      lazyTreeLoader.cache( loadedFilePath, loadedTree );
     }
-    if ( fileTree == null || loadedTree.getFile().getPath().equals( "/" ) ) {
+
+    if ( fileTree == null || loadedFilePath.equals( "/" ) ) {
       fileTree = loadedTree;
     } else {
       lazyTreeLoader.insertTree( fileTree, loadedTree );
     }
+
     repositoryTree = TreeBuilder.buildSolutionTree( fileTree, showHiddenFiles, showLocalizedFileNames, fileFilter );
     selectedTreeItem = repositoryTree.getItem( 0 );
+
     initUI();
     fireFileSelectionChanged();
+
     if ( treeListener != null ) {
       treeListener.loaded();
     }
@@ -227,19 +240,11 @@ public class FileChooser extends VerticalPanel {
    * @throws RequestException
    */
   public void fetchRepositoryDirectory( String folder, int depth, String filter ) throws RequestException {
-    String folderId = ":";
-    if ( folder != null ) {
-      folderId = folder.replace( "/", ":" );
-    }
-    if ( filter == null ) {
-      filter = "*";
-    }
-    RequestBuilder builder = null;
-    builder =
-      new RequestBuilder( RequestBuilder.GET, getFullyQualifiedURL()
-        + "api/repo/files/" + folderId + "/tree?showHidden=" + showHiddenFiles + "&depth=" + depth + "&filter="
-        + filter ); //$NON-NLS-1$
-    builder.setHeader( "accept", "application/json" ); //$NON-NLS-1$ //$NON-NLS-2$
+    final String url = getRepositoryRequestUrl( folder, depth, filter ) + "&ts=" + System.currentTimeMillis();
+
+    final RequestBuilder builder = new RequestBuilder( RequestBuilder.GET, url );
+    builder.setHeader( "accept", "application/json" );
+
     RequestCallback callback = new RequestCallback() {
 
       public void onError( Request request, Throwable exception ) {
@@ -252,22 +257,24 @@ public class FileChooser extends VerticalPanel {
           if ( fileTree == null ) {
             jsonData = lazyTreeLoader.buildTree( jsonData );
           }
+
           JsonToRepositoryFileTreeConverter converter = new JsonToRepositoryFileTreeConverter( jsonData );
           buildTree( converter.getTree(), fileTree != null );
         } else {
-          Window.alert( "Solution Repository not found." ); //$NON-NLS-1$
+          Window.alert( "Solution Repository not found." );
         }
       }
     };
+
     builder.sendRequest( null, callback );
   }
 
   public void fetchRepository( final IDialogCallback completedCallback ) throws RequestException {
-    RequestBuilder builder = null;
-    builder =
-      new RequestBuilder( RequestBuilder.GET, getFullyQualifiedURL()
-        + "api/repo/files/:/tree?showHidden=" + showHiddenFiles + "&depth=-1&filter=*" ); //$NON-NLS-1$
-    builder.setHeader( "accept", "application/json" ); //$NON-NLS-1$ //$NON-NLS-2$
+    final String url = getRepositoryRequestUrl( ":", -1, "*" );
+
+    RequestBuilder builder = new RequestBuilder( RequestBuilder.GET, url );
+    builder.setHeader( "accept", "application/json" );
+
     RequestCallback callback = new RequestCallback() {
 
       public void onError( Request request, Throwable exception ) {
@@ -277,21 +284,37 @@ public class FileChooser extends VerticalPanel {
       public void onResponseReceived( Request request, Response response ) {
         if ( response.getStatusCode() == Response.SC_OK ) {
           String jsonData = response.getText();
+
           JsonToRepositoryFileTreeConverter converter = new JsonToRepositoryFileTreeConverter( jsonData );
-          repositoryTree =
-            TreeBuilder.buildSolutionTree( converter.getTree(), showHiddenFiles, showLocalizedFileNames, fileFilter );
+          repositoryTree = TreeBuilder.buildSolutionTree(
+            converter.getTree(), showHiddenFiles, showLocalizedFileNames, fileFilter );
+
           selectedTreeItem = repositoryTree.getItem( 0 );
+
           initUI();
+
           if ( completedCallback != null ) {
             completedCallback.okPressed();
           }
         } else {
-          Window.alert( "Solution Repository not found." ); //$NON-NLS-1$
+          Window.alert( "Solution Repository not found." );
         }
       }
 
     };
+
     builder.sendRequest( null, callback );
+  }
+
+  private String getRepositoryRequestUrl( String folder, int depth, String filter ) {
+    final String folderId = folder == null ? ":" : folder.replace( "/", ":" );
+
+    if ( filter == null ) {
+      filter = "*";
+    }
+
+    return getFullyQualifiedURL() + "api/repo/files/" + folderId +"/tree?" +
+      "showHidden=" + showHiddenFiles + "&depth=" + depth + "&filter=" + filter;
   }
 
   public void initUI() {
@@ -299,6 +322,7 @@ public class FileChooser extends VerticalPanel {
     if ( mode == FileChooserMode.OPEN_READ_ONLY ) {
       fileNameTextBox.setReadOnly( true );
     }
+
     // We are here because we are initiating a fresh UI for a new directory
     // Since there is no file selected currently, we are setting file selected to false.
     setFileSelected( false );
@@ -312,13 +336,13 @@ public class FileChooser extends VerticalPanel {
     // Path, but we need to display to the user the Localized Path instead.
     List<String> localizedPathSegments = new ArrayList<String>();
     if ( path != null ) {
-      int index = path.indexOf( "/", 0 ); //$NON-NLS-1$
+      int index = path.indexOf( "/", 0 );
       int oldIndex;
       String segment;
       TreeItem childItem;
       while ( index >= 0 ) {
         oldIndex = index;
-        index = path.indexOf( "/", oldIndex + 1 ); //$NON-NLS-1$
+        index = path.indexOf( "/", oldIndex + 1 );
         if ( index >= 0 ) {
           segment = path.substring( oldIndex + 1, index );
         } else {
@@ -336,24 +360,24 @@ public class FileChooser extends VerticalPanel {
     }
 
     navigationListBox = new ListBox();
-    navigationListBox.getElement().setId( "navigationListBox" ); //$NON-NLS-1$
-    navigationListBox.setWidth( "350px" ); //$NON-NLS-1$
+    navigationListBox.getElement().setId( "navigationListBox" );
+    navigationListBox.setWidth( "350px" );
     // now we can find the tree nodes who match the path segments
-    navigationListBox.addItem( "/", "/" ); //$NON-NLS-1$ //$NON-NLS-2$
+    navigationListBox.addItem( "/", "/" );
     // Actual and Localized Path segments will be the same size based on how items get added to their lists.
     for ( int i = 0; i < actualPathSegments.size(); i++ ) {
-      String actualFullPath = ""; //$NON-NLS-1$
-      String localizedFullPath = ""; //$NON-NLS-1$
+      String actualFullPath = "";
+      String localizedFullPath = "";
       for ( int j = 0; j <= i; j++ ) {
         String actualSegmentPath = actualPathSegments.get( j );
         String localizedSegmentPath = localizedPathSegments.get( j );
         if ( actualSegmentPath != null && localizedSegmentPath != null
           && actualSegmentPath.length() > 0 && localizedSegmentPath.length() > 0 ) {
-          actualFullPath += "/" + actualSegmentPath; //$NON-NLS-1$
-          localizedFullPath += "/" + localizedSegmentPath; //$NON-NLS-1$
+          actualFullPath += "/" + actualSegmentPath;
+          localizedFullPath += "/" + localizedSegmentPath;
         }
       }
-      if ( !actualFullPath.equals( "/" ) && !localizedFullPath.equals( "/" ) ) { //$NON-NLS-1$
+      if ( !actualFullPath.equals( "/" ) && !localizedFullPath.equals( "/" ) ) {
         navigationListBox.addItem( localizedFullPath, actualFullPath );
       }
     }
@@ -368,14 +392,15 @@ public class FileChooser extends VerticalPanel {
     clear();
 
     VerticalPanel locationBar = new VerticalPanel();
-    locationBar.add( new Label( FileChooserEntryPoint.messages.getString( "location" ) ) ); //$NON-NLS-1$
+    locationBar.add( new Label( FileChooserEntryPoint.messages.getString( "location" ) ) );
 
     HorizontalPanel navigationBar = new HorizontalPanel();
 
     final Image upDirImage = new Image();
-    upDirImage.setUrl( GWT.getModuleBaseURL() + "images/spacer.gif" ); //$NON-NLS-1$
-    upDirImage.addStyleName( "pentaho-filechooseupbutton" ); //$NON-NLS-1$
-    upDirImage.setTitle( FileChooserEntryPoint.messages.getString( "upOneLevel" ) ); //$NON-NLS-1$
+    upDirImage.setUrl( GWT.getModuleBaseURL() + "images/spacer.gif" );
+    upDirImage.addStyleName( "pentaho-filechooseupbutton" );
+    upDirImage.setTitle( FileChooserEntryPoint.messages.getString( "upOneLevel" ) );
+
     upDirImage.addMouseListener( new MouseListener() {
 
       public void onMouseDown( Widget sender, int x, int y ) {
@@ -394,6 +419,7 @@ public class FileChooser extends VerticalPanel {
       }
 
     } );
+
     upDirImage.addClickListener( new ClickListener() {
       public void onClick( Widget sender ) {
         // go up a dir
@@ -406,41 +432,46 @@ public class FileChooser extends VerticalPanel {
           }
           tmpItem = tmpItem.getParentItem();
         }
+
         Collections.reverse( parentSegments );
-        String myPath = ""; //$NON-NLS-1$
+        String myPath = "";
         // If we have a file selected then we need to go one lesser level deep
         final int loopCount = isFileSelected() ? parentSegments.size() - 2 : parentSegments.size() - 1;
         for ( int i = 0; i < loopCount; i++ ) {
           String pathSegment = parentSegments.get( i );
           if ( pathSegment != null && pathSegment.length() > 0 ) {
-            myPath += "/" + pathSegment; //$NON-NLS-1$
+            myPath += "/" + pathSegment;
           }
         }
-        if ( myPath.equals( "" ) ) { //$NON-NLS-1$
-          myPath = "/"; //$NON-NLS-1$
+
+        if ( myPath.equals( "" ) ) {
+          myPath = "/";
         }
+
         selectedTreeItem = selectedTreeItem.getParentItem();
         if ( selectedTreeItem == null ) {
           selectedTreeItem = repositoryTree.getItem( 0 );
         }
+
         changeToPath( myPath );
       }
     } );
+
     navigationBar.setHorizontalAlignment( HasHorizontalAlignment.ALIGN_LEFT );
     navigationBar.add( navigationListBox );
     navigationBar.setHorizontalAlignment( HasHorizontalAlignment.ALIGN_LEFT );
     navigationBar.add( upDirImage );
-    navigationBar.setCellWidth( upDirImage, "100%" ); //$NON-NLS-1$
+    navigationBar.setCellWidth( upDirImage, "100%" );
     DOM.setStyleAttribute( upDirImage.getElement(), "marginLeft", "4px" );
-    navigationBar.setWidth( "100%" ); //$NON-NLS-1$
+    navigationBar.setWidth( "100%" );
 
     locationBar.add( navigationBar );
-    locationBar.setWidth( "100%" ); //$NON-NLS-1$
+    locationBar.setWidth( "100%" );
 
-    Label filenameLabel = new Label( FileChooserEntryPoint.messages.getString( "filename" ) ); //$NON-NLS-1$
-    filenameLabel.setWidth( "550px" ); //$NON-NLS-1$
+    Label filenameLabel = new Label( FileChooserEntryPoint.messages.getString( "filename" ) );
+    filenameLabel.setWidth( "550px" );
     add( filenameLabel );
-    fileNameTextBox.setWidth( "300px" ); //$NON-NLS-1$
+    fileNameTextBox.setWidth( "300px" );
     add( fileNameTextBox );
     add( locationBar );
     add( buildFilesList( selectedTreeItem ) );
@@ -448,28 +479,31 @@ public class FileChooser extends VerticalPanel {
 
   public Widget buildFilesList( TreeItem parentTreeItem ) {
     VerticalPanel filesListPanel = new VerticalPanel();
-    filesListPanel.setWidth( "100%" ); //$NON-NLS-1$
+    filesListPanel.setWidth( "100%" );
 
     ScrollPanel filesScroller = new ScrollPanel();
 
-    filesScroller.setStyleName( "fileChooser-scrollPanel" ); //$NON-NLS-1$
+    filesScroller.setStyleName( "fileChooser-scrollPanel" );
 
     FlexTable filesListTable = new FlexTable();
-    filesListTable.setWidth( "100%" ); //$NON-NLS-1$
+    filesListTable.setWidth( "100%" );
     filesListTable.setCellSpacing( 0 );
-    Label nameLabel = new Label( FileChooserEntryPoint.messages.getString( "name" ), false ); //$NON-NLS-1$
-    nameLabel.setStyleName( "fileChooserHeader" ); //$NON-NLS-1$
-    Label typeLabel = new Label( FileChooserEntryPoint.messages.getString( "type" ), false ); //$NON-NLS-1$
-    typeLabel.setStyleName( "fileChooserHeader" ); //$NON-NLS-1$
-    Label dateLabel = new Label( FileChooserEntryPoint.messages.getString( "dateModified" ), false ); //$NON-NLS-1$
-    dateLabel.setStyleName( "fileChooserHeader" ); //$NON-NLS-1$
+
+    Label nameLabel = new Label( FileChooserEntryPoint.messages.getString( "name" ), false );
+    nameLabel.setStyleName( "fileChooserHeader" );
+
+    Label typeLabel = new Label( FileChooserEntryPoint.messages.getString( "type" ), false );
+    typeLabel.setStyleName( "fileChooserHeader" );
+
+    Label dateLabel = new Label( FileChooserEntryPoint.messages.getString( "dateModified" ), false );
+    dateLabel.setStyleName( "fileChooserHeader" );
 
     ElementUtils.preventTextSelection( nameLabel.getElement() );
     ElementUtils.preventTextSelection( typeLabel.getElement() );
     ElementUtils.preventTextSelection( dateLabel.getElement() );
 
     filesListTable.setWidget( 0, 0, nameLabel );
-    filesListTable.getCellFormatter().setWidth( 0, 0, "100%" ); //$NON-NLS-1$
+    filesListTable.getCellFormatter().setWidth( 0, 0, "100%" );
     filesListTable.setWidget( 0, 1, typeLabel );
     filesListTable.setWidget( 0, 2, dateLabel );
 
@@ -495,10 +529,12 @@ public class FileChooser extends VerticalPanel {
         addFileToList( repositoryFileTree, childItem, filesListTable, row++ );
       }
     }
-    filesListTable.setWidth( "100%" ); //$NON-NLS-1$
+
+    filesListTable.setWidth( "100%" );
     filesScroller.setWidget( filesListTable );
-    filesListTable.setWidth( "100%" ); //$NON-NLS-1$
+    filesListTable.setWidth( "100%" );
     filesListPanel.add( filesScroller );
+
     return filesListPanel;
   }
 
@@ -529,71 +565,76 @@ public class FileChooser extends VerticalPanel {
             handleFileClicked( item, isDir, event, this.getElement() );
             break;
           case Event.ONMOUSEOVER:
-            this.addStyleDependentName( "over" ); //$NON-NLS-1$
+            this.addStyleDependentName( "over" );
             break;
           case Event.ONMOUSEOUT:
-            this.removeStyleDependentName( "over" ); //$NON-NLS-1$
+            this.removeStyleDependentName( "over" );
             break;
         }
       }
     };
+
     // biserver-2719: concatenate the name with fileChooser_ so the ids are unique in Mantle
-    myNameLabel.getElement().setAttribute( "id", "fileChooser_".concat( file.getId() ) ); //$NON-NLS-1$ //$NON-NLS-2$
+    myNameLabel.getElement().setAttribute( "id", "fileChooser_".concat( file.getId() ) );
     myNameLabel.sinkEvents( Event.ONDBLCLICK | Event.ONCLICK );
     myNameLabel.sinkEvents( Event.ONMOUSEOVER | Event.ONMOUSEOUT );
     myNameLabel.setTitle( file.getTitle() );
-    myNameLabel.setStyleName( "fileChooserCellLabel" ); //$NON-NLS-1$
+    myNameLabel.setStyleName( "fileChooserCellLabel" );
+
     HorizontalPanel fileNamePanel = new HorizontalPanel();
     Image fileImage = new Image() {
       public void onBrowserEvent( Event event ) {
         handleFileClicked( item, isDir, event, myNameLabel.getElement() );
       }
     };
+
     fileImage.setUrl( GWT.getModuleBaseURL() + "images/spacer.gif" );
     fileImage.addStyleName( "icon-small" );
     fileImage.addStyleName( "clickable" );
     fileImage.sinkEvents( Event.ONDBLCLICK | Event.ONCLICK );
+
     if ( isDir ) {
       fileImage.addStyleName( "icon-folder" );
     } else {
 
-      if ( fileName.endsWith( "waqr.xaction" ) ) { //$NON-NLS-1$
+      if ( fileName.endsWith( "waqr.xaction" ) ) {
         fileImage.addStyleName( "icon-waqr-report" );
-      } else if ( fileName.endsWith( "analysisview.xaction" ) ) { //$NON-NLS-1$
+      } else if ( fileName.endsWith( "analysisview.xaction" ) ) {
         fileImage.addStyleName( "icon-analysis" );
-      } else if ( fileName.endsWith( ".url" ) ) { //$NON-NLS-1$
+      } else if ( fileName.endsWith( ".url" ) ) {
         fileImage.addStyleName( "icon-url" );
-      } else if ( fileName.endsWith( "xanalyzer" ) ) { //$NON-NLS-1$
+      } else if ( fileName.endsWith( "xanalyzer" ) ) {
         fileImage.addStyleName( "icon-analyzer" );
-      } else if ( fileName.endsWith( "prpti" ) ) { //$NON-NLS-1$
+      } else if ( fileName.endsWith( "prpti" ) ) {
         fileImage.addStyleName( "icon-pir-report" );
-      } else if ( fileName.endsWith( "prpt" ) ) { //$NON-NLS-1$
+      } else if ( fileName.endsWith( "prpt" ) ) {
         fileImage.addStyleName( "icon-prpt-report" );
-      } else if ( fileName.endsWith( "xdash" ) ) { //$NON-NLS-1$
+      } else if ( fileName.endsWith( "xdash" ) ) {
         fileImage.addStyleName( "icon-dashboard" );
       } else {
         fileImage.addStyleName( "icon-xaction" );
       }
     }
+
     fileNamePanel.add( fileImage );
     fileNamePanel.add( myNameLabel );
-    DOM.setStyleAttribute( myNameLabel.getElement(), "cursor", "default" ); //$NON-NLS-1$ //$NON-NLS-2$
+    DOM.setStyleAttribute( myNameLabel.getElement(), "cursor", "default" );
 
     Label typeLabel =
       new Label(
         isDir
           ? FileChooserEntryPoint.messages.getString( "folder" ) : FileChooserEntryPoint.messages.getString( "file" ),
-        false ); //$NON-NLS-1$ //$NON-NLS-2$
+        false );
 
     ElementUtils.preventTextSelection( myNameLabel.getElement() );
     ElementUtils.preventTextSelection( typeLabel.getElement() );
     if ( myDateLabel != null ) {
       ElementUtils.preventTextSelection( myDateLabel.getElement() );
     }
-    fileNamePanel.setStyleName( "fileChooserCell" ); //$NON-NLS-1$
-    typeLabel.setStyleName( "fileChooserCell" ); //$NON-NLS-1$
+    fileNamePanel.setStyleName( "fileChooserCell" );
+    typeLabel.setStyleName( "fileChooserCell" );
     if ( myDateLabel != null ) {
-      myDateLabel.setStyleName( "fileChooserCell" ); //$NON-NLS-1$
+      myDateLabel.setStyleName( "fileChooserCell" );
     }
     filesListTable.setWidget( row + 1, 0, fileNamePanel );
     filesListTable.setWidget( row + 1, 1, typeLabel );
@@ -605,11 +646,12 @@ public class FileChooser extends VerticalPanel {
   private void handleFileClicked( final TreeItem item, final boolean isDir, final Event event,
                                   com.google.gwt.user.client.Element sourceElement ) {
     boolean eventWeCareAbout = false;
-    TreeItem tmpItem = null;
+    TreeItem tmpItem;
     if ( ( DOM.eventGetType( event ) & Event.ONDBLCLICK ) == Event.ONDBLCLICK
       || ( DOM.eventGetType( event ) & Event.ONCLICK ) == Event.ONCLICK ) {
       eventWeCareAbout = true;
     }
+
     if ( eventWeCareAbout ) {
       setFileSelected( true );
       selectedTreeItem = tmpItem = item;
@@ -624,11 +666,11 @@ public class FileChooser extends VerticalPanel {
         tmpItem = tmpItem.getParentItem();
       }
       Collections.reverse( parentSegments );
-      String myPath = ""; //$NON-NLS-1$
+      String myPath = "";
       for ( int i = 0; isDir ? i < parentSegments.size() : i < parentSegments.size() - 1; i++ ) {
         String segment = parentSegments.get( i );
         if ( segment != null && segment.length() > 0 ) {
-          myPath += "/" + segment; //$NON-NLS-1$
+          myPath += "/" + segment;
         }
       }
       setSelectedPath( myPath );
@@ -640,6 +682,7 @@ public class FileChooser extends VerticalPanel {
         }
       }
     }
+
     // double click
     if ( ( DOM.eventGetType( event ) & Event.ONDBLCLICK ) == Event.ONDBLCLICK ) {
       if ( isDir ) {
@@ -657,12 +700,12 @@ public class FileChooser extends VerticalPanel {
       // highlight row
       if ( lastSelectedFileElement != null ) {
         com.google.gwt.dom.client.Element parentRow =
-          ElementUtils.findElementAboveByTagName( lastSelectedFileElement, "table" ); //$NON-NLS-1$
+          ElementUtils.findElementAboveByTagName( lastSelectedFileElement, "table" );
         parentRow.removeClassName( "pentaho-file-chooser-selection" );
       }
       com.google.gwt.dom.client.Element parentRow =
-        ElementUtils.findElementAboveByTagName( sourceElement, "table" ); //$NON-NLS-1$
-      parentRow.addClassName( "pentaho-file-chooser-selection" ); //$NON-NLS-1$
+        ElementUtils.findElementAboveByTagName( sourceElement, "table" );
+      parentRow.addClassName( "pentaho-file-chooser-selection" );
       lastSelectedFileElement = sourceElement;
     }
   }
@@ -686,6 +729,7 @@ public class FileChooser extends VerticalPanel {
         break;
       }
     }
+
     return selectedItem;
   }
 
@@ -697,6 +741,7 @@ public class FileChooser extends VerticalPanel {
         return item;
       }
     }
+
     return null;
   }
 
@@ -718,9 +763,8 @@ public class FileChooser extends VerticalPanel {
 
   public void setFileChooserRepositoryFileTree( RepositoryFileTree fileChooserRepositoryFileTree ) {
     this.fileTree = fileChooserRepositoryFileTree;
-    repositoryTree =
-      TreeBuilder.buildSolutionTree( fileChooserRepositoryFileTree, showHiddenFiles, showLocalizedFileNames,
-        fileFilter );
+    repositoryTree = TreeBuilder.buildSolutionTree( fileChooserRepositoryFileTree, showHiddenFiles,
+      showLocalizedFileNames, fileFilter );
     initUI();
   }
 
@@ -750,10 +794,10 @@ public class FileChooser extends VerticalPanel {
   }
 
   public String getSolution() {
-    if ( getSelectedPath().indexOf( "/", 1 ) == -1 ) { //$NON-NLS-1$
+    if ( getSelectedPath().indexOf( "/", 1 ) == -1 ) {
       return getSelectedPath().substring( 1 );
     } else {
-      return getSelectedPath().substring( 1, getSelectedPath().indexOf( "/", 1 ) ); //$NON-NLS-1$
+      return getSelectedPath().substring( 1, getSelectedPath().indexOf( "/", 1 ) );
     }
   }
 
@@ -771,14 +815,12 @@ public class FileChooser extends VerticalPanel {
         fileNames.add( file.getName() );
       }
     }
+
     return fileNames;
   }
 
   public boolean doesFileExist( final String path ) {
-    if ( search( this.fileTree, path ) != null ) {
-      return true;
-    }
-    return false;
+    return search( this.fileTree, path ) != null;
   }
 
   public String getActualFileName() {
@@ -798,15 +840,14 @@ public class FileChooser extends VerticalPanel {
   }
 
   public FileFilter getFileFilter() {
-
     return fileFilter;
   }
 
   public void setFileFilter( FileFilter fileFilter ) {
-
     this.fileFilter = fileFilter;
 
     repositoryTree = TreeBuilder.buildSolutionTree( fileTree, showHiddenFiles, showLocalizedFileNames, fileFilter );
+
     initUI();
   }
 
@@ -815,10 +856,11 @@ public class FileChooser extends VerticalPanel {
   }
 
   public boolean doesSelectedFileExist( String ext ) {
-    String fileName = this.selectedPath + "/" + this.actualFileName; //$NON-NLS-1$
+    String fileName = this.selectedPath + "/" + this.actualFileName;
     if ( !StringUtils.isEmpty( ext ) && !fileName.endsWith( ext ) ) {
       fileName = fileName + ext;
     }
+
     return search( fileTree, fileName ) != null;
   }
 
@@ -829,6 +871,7 @@ public class FileChooser extends VerticalPanel {
 
   public void changeToPath( String path ) {
     setSelectedPath( path );
+
     if ( !isLazy ) {
       initUI();
       fireFileSelectionChanged();

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/filechooser/FileChooserDialog.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/filechooser/FileChooserDialog.java
@@ -12,9 +12,8 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002 - 2020 Hitachi Vantara..  All rights reserved.
  */
-
 package org.pentaho.gwt.widgets.client.filechooser;
 
 import java.util.ArrayList;
@@ -35,9 +34,9 @@ import com.google.gwt.user.client.ui.KeyboardListener;
 
 public class FileChooserDialog extends PromptDialogBox implements FileChooserListener {
 
-  //private static final String ILLEGAL_NAME_CHARS = "\\\'/?%*:|\"<>&"; //$NON-NLS-1$
   private static String OPEN = FileChooserEntryPoint.messages.getString( "Open" );
   private static String SAVE = FileChooserEntryPoint.messages.getString( "Save" );
+
   private static String lastOpenLocation = "";
   private static boolean isDirty = false;
 
@@ -49,20 +48,17 @@ public class FileChooserDialog extends PromptDialogBox implements FileChooserLis
   private boolean submitOnEnter = true;
 
   public FileChooserDialog( FileChooserMode mode, String selectedPath, boolean autoHide, boolean modal ) {
-    this(
-        mode,
-        selectedPath,
-        autoHide,
-        modal,
-        mode == FileChooserMode.OPEN
-            ? FileChooserEntryPoint.messages.getString( "Open" ) : FileChooserEntryPoint.messages.getString( "Save" ), mode == FileChooserMode.OPEN ? FileChooserEntryPoint.messages.getString( "Open" ) : FileChooserEntryPoint.messages.getString( "Save" ) ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+    this( mode, selectedPath, autoHide, modal, mode == FileChooserMode.OPEN ? OPEN : SAVE,
+      mode == FileChooserMode.OPEN ? OPEN : SAVE );
   }
 
-  public FileChooserDialog( FileChooserMode mode, String selectedPath, boolean autoHide, boolean modal, String title,
-      String okText ) {
+  public FileChooserDialog( FileChooserMode mode, String selectedPath, boolean autoHide, boolean modal,
+                            String title, String okText ) {
     super( title, okText, FileChooserEntryPoint.messages.getString( "Cancel" ), false, true );
+
     showGlassPane();
     setupNativeHooks();
+
     fileChooser = new FileChooser( mode, selectedPath, new IDialogCallback() {
       public void cancelPressed() {
 
@@ -72,14 +68,16 @@ public class FileChooserDialog extends PromptDialogBox implements FileChooserLis
         center();
       }
     } );
+
     this.setContent( fileChooser );
 
-    fileChooser.setWidth( "100%" ); //$NON-NLS-1$
+    fileChooser.setWidth( "100%" );
     setValidatorCallback( new IDialogValidatorCallback() {
       public boolean validate() {
         return isFileNameValid();
       }
     } );
+
     IDialogCallback callback = new IDialogCallback() {
 
       public void cancelPressed() {
@@ -93,6 +91,7 @@ public class FileChooserDialog extends PromptDialogBox implements FileChooserLis
       }
 
     };
+
     setCallback( callback );
     fileChooser.addFileChooserListener( this );
   }
@@ -134,6 +133,7 @@ public class FileChooserDialog extends PromptDialogBox implements FileChooserLis
       if ( file != null && file.getPath().equals( folderPath ) ) {
         return file;
       }
+
       if ( file != null ) {
         for ( RepositoryFileTree treeItem : tree.getChildren() ) {
           file = doesFolderExist( treeItem, folderPath );
@@ -143,35 +143,50 @@ public class FileChooserDialog extends PromptDialogBox implements FileChooserLis
         }
       }
     } catch ( Exception e ) {
-      return null;
+      // does nothing
     }
+
     return null;
   }
 
-  public FileChooserDialog( FileChooserMode mode, String selectedPath, RepositoryFileTree fileTree, boolean autoHide,
-      boolean modal, String title, String okText ) {
+  public FileChooserDialog( FileChooserMode mode, String selectedPath,
+                            boolean autoHide, boolean modal, boolean showHiddenFiles ) {
+    this( mode, selectedPath, null, autoHide, modal, mode == FileChooserMode.OPEN ? OPEN : SAVE,
+      mode == FileChooserMode.OPEN ? OPEN : SAVE, showHiddenFiles );
+  }
+
+  public FileChooserDialog( FileChooserMode mode, String selectedPath, RepositoryFileTree fileTree,
+                            boolean autoHide, boolean modal ) {
+    this( mode, selectedPath, fileTree, autoHide, modal, mode == FileChooserMode.OPEN ? OPEN : SAVE,
+      mode == FileChooserMode.OPEN ? OPEN : SAVE );
+  }
+
+  public FileChooserDialog( FileChooserMode mode, String selectedPath, RepositoryFileTree fileTree,
+                            boolean autoHide, boolean modal, String title, String okText ) {
     this( mode, selectedPath, fileTree, autoHide, modal, title, okText, false );
   }
 
-  public FileChooserDialog( FileChooserMode mode, String selectedPath, boolean autoHide, boolean modal, boolean showHiddenFiles ) {
-    this( mode, selectedPath, null, autoHide, modal, mode == FileChooserMode.OPEN ? OPEN : SAVE,
-      mode == FileChooserMode.OPEN ? OPEN : SAVE, showHiddenFiles, true );
+  public FileChooserDialog( FileChooserMode mode, String selectedPath, RepositoryFileTree fileTree,
+                            boolean autoHide, boolean modal, boolean showHiddenFiles ) {
+    this( mode, selectedPath, fileTree, autoHide, modal, mode == FileChooserMode.OPEN ? OPEN : SAVE,
+      mode == FileChooserMode.OPEN ? OPEN : SAVE, showHiddenFiles );
   }
 
-  public FileChooserDialog( FileChooserMode mode, String selectedPath, RepositoryFileTree fileTree, boolean autoHide,
-                            boolean modal, String title, String okText, boolean showHiddenFiles ) {
-    this( mode, selectedPath, fileTree, autoHide, modal, title, okText, showHiddenFiles, false );
-  }
-
-  public FileChooserDialog( FileChooserMode mode, String selectedPath, RepositoryFileTree fileTree, boolean autoHide,
-      boolean modal, String title, String okText, boolean showHiddenFiles, boolean isLazy ) {
-    super( title, okText, FileChooserEntryPoint.messages.getString( "Cancel" ), false, true ); //$NON-NLS-1$
+  public FileChooserDialog( FileChooserMode mode, String selectedPath, RepositoryFileTree fileTree,
+                            boolean autoHide, boolean modal, String title, String okText, boolean showHiddenFiles ) {
+    super( title, okText, FileChooserEntryPoint.messages.getString( "Cancel" ), false, true );
     fileChooser = new FileChooser( showHiddenFiles );
+
     setContent( fileChooser );
-    fileChooser.setWidth( "100%" ); //$NON-NLS-1$
+
+    fileChooser.setWidth( "100%" );
     fileChooser.setMode( mode );
-    fileChooser.setLazy( fileTree == null );
+
+    final boolean isLazy = fileTree == null;
+    fileChooser.setLazy( isLazy );
+
     setupNativeHooks();
+
     if ( mode.equals( FileChooserMode.OPEN ) ) {
       if ( getLastOpenLocation() == null ) {
         fileChooser.setSelectedPath( getHomeFolderLocation() );
@@ -182,12 +197,11 @@ public class FileChooserDialog extends PromptDialogBox implements FileChooserLis
         }
       }
     }
+
     if ( mode.equals( FileChooserMode.SAVE ) ) {
-      if ( StringUtils.isEmpty( selectedPath ) ) {
-        fileChooser.setSelectedPath( getHomeFolderLocation() );
-      } else {
-        fileChooser.setSelectedPath( selectedPath );
-      }
+      final String path = StringUtils.isEmpty( selectedPath ) ? getHomeFolderLocation() : selectedPath;
+
+      fileChooser.setSelectedPath( path );
     }
 
     setValidatorCallback( new IDialogValidatorCallback() {
@@ -195,6 +209,7 @@ public class FileChooserDialog extends PromptDialogBox implements FileChooserLis
         return isFileNameValid();
       }
     } );
+
     IDialogCallback callback = new IDialogCallback() {
 
       public void cancelPressed() {
@@ -208,10 +223,13 @@ public class FileChooserDialog extends PromptDialogBox implements FileChooserLis
       }
 
     };
+
     setCallback( callback );
+
     fileChooser.addFileChooserListener( this );
     fileChooser.setTreeListener( new FileChooserTreeListener() {
-      @Override public void loaded() {
+      @Override
+      public void loaded() {
         center();
       }
     } );
@@ -224,36 +242,11 @@ public class FileChooserDialog extends PromptDialogBox implements FileChooserLis
       }
     } else {
       fileChooser.fileTree = fileTree;
-      fileChooser.repositoryTree =
-        TreeBuilder.buildSolutionTree( fileTree, fileChooser.showHiddenFiles, fileChooser.showLocalizedFileNames,
-          filter );
+      fileChooser.repositoryTree = TreeBuilder.buildSolutionTree(
+        fileTree, fileChooser.showHiddenFiles, fileChooser.showLocalizedFileNames, filter );
       fileChooser.selectedTreeItem = fileChooser.repositoryTree.getItem( 0 );
       fileChooser.initUI();
     }
-  }
-
-  public FileChooserDialog( FileChooserMode mode, String selectedPath, RepositoryFileTree fileTree, boolean autoHide,
-      boolean modal ) {
-    this(
-        mode,
-        selectedPath,
-        fileTree,
-        autoHide,
-        modal,
-        mode == FileChooserMode.OPEN
-            ? FileChooserEntryPoint.messages.getString( "Open" ) : FileChooserEntryPoint.messages.getString( "Save" ), mode == FileChooserMode.OPEN ? FileChooserEntryPoint.messages.getString( "Open" ) : FileChooserEntryPoint.messages.getString( "Save" ) ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-  }
-
-  public FileChooserDialog( FileChooserMode mode, String selectedPath, RepositoryFileTree fileTree, boolean autoHide,
-      boolean modal, boolean showHiddenFiles ) {
-    this(
-        mode,
-        selectedPath,
-        fileTree,
-        autoHide,
-        modal,
-        mode == FileChooserMode.OPEN
-            ? FileChooserEntryPoint.messages.getString( "Open" ) : FileChooserEntryPoint.messages.getString( "Save" ), mode == FileChooserMode.OPEN ? FileChooserEntryPoint.messages.getString( "Open" ) : FileChooserEntryPoint.messages.getString( "Save" ), showHiddenFiles ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
   }
 
   public void addFileChooserListener( FileChooserListener listener ) {
@@ -271,13 +264,11 @@ public class FileChooserDialog extends PromptDialogBox implements FileChooserLis
   }
 
   public boolean doesSelectedFileExist( String ext ) {
-    boolean result = false;
     if ( StringUtils.isEmpty( ext ) ) {
-      result = fileChooser.doesSelectedFileExist();
-    } else {
-      result = fileChooser.doesSelectedFileExist( ext );
+      return fileChooser.doesSelectedFileExist();
     }
-    return result;
+
+    return fileChooser.doesSelectedFileExist( ext );
   }
 
   public List<String> getFilesInPath( final RepositoryFileTree fileTreeItem ) {
@@ -289,28 +280,27 @@ public class FileChooserDialog extends PromptDialogBox implements FileChooserLis
   }
 
   public FileFilter getFileFilter() {
-
     return filter;
   }
 
   public void setFileFilter( FileFilter filter ) {
-
     this.filter = filter;
+
     fileChooser.setFileFilter( filter );
   }
 
   /**
    * This method get the actual file name of the selected file
-   * 
+   *
    * @return the actual file name
    */
   private String getActualFileName() {
     final String actualFileName = fileChooser.getActualFileName();
-    if ( actualFileName != null && !"".equals( actualFileName ) ) { //$NON-NLS-1$
+    if ( actualFileName != null && !"".equals( actualFileName ) ) {
       return actualFileName;
-    } else {
-      return "";
     }
+
+    return "";
   }
 
   /*
@@ -356,6 +346,7 @@ public class FileChooserDialog extends PromptDialogBox implements FileChooserLis
           setLastOpenLocation( fileChooser.selectedPath );
         }
       }
+
       this.hide();
     }
   }
@@ -367,7 +358,6 @@ public class FileChooserDialog extends PromptDialogBox implements FileChooserLis
   }
 
   public void dialogCanceled() {
-
     for ( FileChooserListener listener : listeners ) {
       listener.dialogCanceled();
     }
@@ -376,6 +366,7 @@ public class FileChooserDialog extends PromptDialogBox implements FileChooserLis
   @Override
   public void hide() {
     GlassPane.getInstance().hide();
+
     super.hide();
   }
 
@@ -387,6 +378,7 @@ public class FileChooserDialog extends PromptDialogBox implements FileChooserLis
 
   private void showGlassPane() {
     GlassPane.getInstance().show();
+
     super.initializePageBackground();
     super.block();
   }
@@ -418,6 +410,7 @@ public class FileChooserDialog extends PromptDialogBox implements FileChooserLis
         onCancel();
         break;
     }
+
     return true;
   }
 }

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/filechooser/FileChooserEntryPoint.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/filechooser/FileChooserEntryPoint.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2020 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002 - 2020 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.gwt.widgets.client.filechooser;
@@ -66,36 +66,14 @@ public class FileChooserEntryPoint implements EntryPoint, IResourceBundleLoadCal
 
   public void openFileChooserDialog( final JavaScriptObject callback, String selectedPath ) {
     FileChooserDialog dialog = new FileChooserDialog( FileChooserMode.OPEN, selectedPath, false, true );
-    dialog.addFileChooserListener( new FileChooserListener() {
-      public void fileSelected( RepositoryFile file, String filePath, String fileName, String title ) {
-        notifyCallback( callback, file, filePath, fileName, title );
-      }
-
-      public void fileSelectionChanged( RepositoryFile file, String filePath, String fileName, String title ) {
-      }
-
-      public void dialogCanceled() {
-        notifyCallbackCanceled( callback );
-      }
-    } );
+    addFileChooserListener( dialog, callback );
   }
 
   public void openFolderChooserDialog( final JavaScriptObject callback, String selectedPath ) {
     FileChooserDialog dialog = new FileChooserDialog( FileChooserMode.OPEN, selectedPath, false, true );
-    dialog.addFileChooserListener( new FileChooserListener() {
-      public void fileSelected( RepositoryFile file, String filePath, String fileName, String title ) {
-        notifyCallback( callback, file, filePath, fileName, title );
-      }
+    addFileChooserListener( dialog, callback );
 
-      public void fileSelectionChanged( RepositoryFile file, String filePath, String fileName, String title ) {
-      }
-
-      public void dialogCanceled() {
-        notifyCallbackCanceled( callback );
-      }
-    } );
     dialog.setFileFilter( new FileFilter() {
-
       @Override
       public boolean accept( String name, boolean isDirectory, boolean isVisible ) {
         return isDirectory;


### PR DESCRIPTION
…Save (#749)

* [BACKLOG-32839] Reintroducing timestamp in the repository tree request
 * also removed constructor with unused variable "isLazy"

These change are needed by ANALYZER-3904 because ANALYZER-3904 depends on BACKLOG-27462 which introduced a regression addressed by BACKLOG-32839.