### PR TITLE
[SP-5846] Backport of BISERVER-14495 - Schedule Information across timezone is shown incorrectly when the recurrence is "Weekly". (9.1 Suite)

### DIFF
--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/utils/TimeUtil.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/utils/TimeUtil.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.gwt.widgets.client.utils;
@@ -544,29 +544,31 @@ public class TimeUtil {
    * timezone id - e.g. "Eastern Daylight Time (UTC-0500)"
    * dateTime format - e.g. "2018-02-27T07:30:00-05:00"
    *
-   * @param selectedTime The time selected by the user which is compared against the timezone diff between client and target
+   * @param selectedHour The hour selected by the user which is compared against the timezone diff between client and target
+   * @param selectedMinute The minute selected by the user which is compared against the timezone diff between client and target
    * @param targetTimezoneInfo The target timezone information in the formats described above
    * @return The calculated day variance
    */
-  public static int getDayVariance( int selectedTime, String targetTimezoneInfo ) {
+  public static int getDayVariance( int selectedHour, int selectedMinute, String targetTimezoneInfo ) {
 
     boolean isTimezoneId = targetTimezoneInfo.contains( "UTC" );
 
     int targetOffset = targetTimezoneInfo.endsWith( "Z" ) ? 0 : getTargetOffset( targetTimezoneInfo, isTimezoneId );
-    int clientOffset = -getClientOffsetTimeZone() / 60;
+    double clientOffset = -getClientOffsetTimeZone() / MINUTES_IN_HOUR;
+    double selectedTime = selectedHour + ( selectedMinute != 0 ? selectedMinute / (double) MINUTES_IN_HOUR : 0 );
 
     // if client side has the timezone ahead of target's timezone, then we should compare against client's start of the day
     // client2target -> -1 and target2client -> +1
     if ( clientOffset > targetOffset ) {
-      int timezoneDiff = targetOffset - clientOffset;
+      double timezoneDiff = targetOffset - clientOffset;
       if ( selectedTime + timezoneDiff < 0 ) {
         return isTimezoneId ? -1 : 1;
       }
     // if client side has the timezone behind of target's timezone, then we should compare against client's end of the day
     // client2target -> +1 and target2client -> -1
     } else {
-      int timezoneDiff = clientOffset - targetOffset;
-      if ( selectedTime - timezoneDiff > 23 ) {
+      double timezoneDiff = clientOffset - targetOffset;
+      if ( selectedTime - timezoneDiff >= HOURS_IN_DAY ) {
         return isTimezoneId ? 1 : -1;
       }
     }
@@ -618,7 +620,7 @@ public class TimeUtil {
     return ( dayVariance > 0 ) ? currentDay.getNext() : currentDay.getPrevious();
   }
 
-  public static native int getClientOffsetTimeZone() /*-{
+  public static native double getClientOffsetTimeZone() /*-{
       return new Date().getTimezoneOffset();
   }-*/;
 }

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.mantle.client.dialogs.scheduling;
@@ -353,7 +353,7 @@ public class ScheduleRecurrenceDialog extends AbstractWizardDialog {
       int weekDayVariance = 0;
 
       if ( targetTimezone != null ) {
-        weekDayVariance = TimeUtil.getDayVariance( startDate.getHours(), targetTimezone );
+        weekDayVariance = TimeUtil.getDayVariance( startDate.getHours(), startDate.getMinutes(), targetTimezone );
       }
 
       for ( DayOfWeek dayOfWeek : daysOfWeek ) {

--- a/widgets/src/main/java/org/pentaho/mantle/client/workspace/JsJobTrigger.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/workspace/JsJobTrigger.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.mantle.client.workspace;
@@ -403,7 +403,7 @@ public class JsJobTrigger extends JavaScriptObject {
 
           int variance = 0;
           if ( DateTimeFormat.getFormat( "yyyy-MM-dd'T'HH:mm:ssZZZ" ).parseStrict( getNativeStartTime() ) != null ) {
-            variance = TimeUtil.getDayVariance( getStartTime().getHours(), getNativeStartTime() );
+            variance = TimeUtil.getDayVariance( getStartTime().getHours(), getStartTime().getMinutes(), getNativeStartTime() );
           }
 
           int adjustedDayOfWeek =  TimeUtil.getDayOfWeek( DayOfWeek.get( getDayOfWeekRecurrences()[0] - 1 ), variance );

--- a/widgets/src/test/java/org/pentaho/gwt/widgets/client/utils/TimeUtilTest.java
+++ b/widgets/src/test/java/org/pentaho/gwt/widgets/client/utils/TimeUtilTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.gwt.widgets.client.utils;
@@ -28,23 +28,38 @@ public class TimeUtilTest {
   @Test
   public void testGetDayVariance_timezoneIdFormat() {
     String timezoneIdFormat = "Eastern Daylight Time (UTC-0500)";
-    int dayVariance = TimeUtil.getDayVariance( 3, timezoneIdFormat );
-    assertEquals( dayVariance, -1 );
+    int dayVariance = TimeUtil.getDayVariance( 3, 0, timezoneIdFormat );
+    assertEquals( -1, dayVariance );
 
     timezoneIdFormat = "Japan Daylight Time (UTC+0900)";
-    dayVariance = TimeUtil.getDayVariance( 20, timezoneIdFormat );
-    assertEquals( dayVariance, 1 );
+    dayVariance = TimeUtil.getDayVariance( 20, 0, timezoneIdFormat );
+    assertEquals( 1, dayVariance );
   }
 
   @Test
   public void testGetDayVariance_dateTimeFormat() {
     String dateTimeFormat = "2018-01-01T07:30:00-05:00";
-    int dayVariance = TimeUtil.getDayVariance( 3, dateTimeFormat );
-    assertEquals( dayVariance, 1 );
+    int dayVariance = TimeUtil.getDayVariance( 3, 0, dateTimeFormat );
+    assertEquals( 1, dayVariance );
 
     dateTimeFormat = "2018-01-01T07:30:00+05:00";
-    dayVariance = TimeUtil.getDayVariance( 20, dateTimeFormat );
-    assertEquals( dayVariance, -1 );
+    dayVariance = TimeUtil.getDayVariance( 20, 0, dateTimeFormat );
+    assertEquals( -1, dayVariance );
+
+    dateTimeFormat = "2020-11-05T05:30:00-05:30";
+    dayVariance = TimeUtil.getDayVariance( 5, 29, dateTimeFormat );
+    assertEquals( 0, dayVariance );
+
+    dateTimeFormat = "2020-11-05T05:30:00-05:30";
+    dayVariance = TimeUtil.getDayVariance( 0, 31, dateTimeFormat );
+    assertEquals( 1, dayVariance );
+  }
+
+  @Test
+  public void getNextDayWrapTest() {
+    TimeUtil.DayOfWeek day = TimeUtil.DayOfWeek.SAT;
+    int nextDay = day.getNext();
+    assertEquals( TimeUtil.DayOfWeek.SUN.value(), nextDay );
   }
 
   @Test

--- a/widgets/src/test/java/org/pentaho/gwt/widgets/client/utils/TimeUtilTest.java
+++ b/widgets/src/test/java/org/pentaho/gwt/widgets/client/utils/TimeUtilTest.java
@@ -21,6 +21,7 @@ import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+
 import static org.junit.Assert.assertEquals;
 
 @RunWith( GwtMockitoTestRunner.class )
@@ -47,7 +48,7 @@ public class TimeUtilTest {
     assertEquals( -1, dayVariance );
 
     dateTimeFormat = "2020-11-05T05:30:00-05:30";
-    dayVariance = TimeUtil.getDayVariance( 5, 29, dateTimeFormat );
+    dayVariance = TimeUtil.getDayVariance( 6, 29, dateTimeFormat );
     assertEquals( 0, dayVariance );
 
     dateTimeFormat = "2020-11-05T05:30:00-05:30";
@@ -72,5 +73,51 @@ public class TimeUtilTest {
   public void testGetDayOfWeek_previous() {
     int previousDayOfWeek = TimeUtil.getDayOfWeek( TimeUtil.DayOfWeek.MON, -1 );
     assertEquals( TimeUtil.DayOfWeek.SUN.ordinal(), previousDayOfWeek );
+  }
+
+  @Test
+  public void getTargetOffsetFromTimezoneStringTest() {
+    double timeOffset = TimeUtil.getTargetOffsetFromTimezoneString( "Eastern Daylight Time (UTC-0500)" );
+    assertEquals( -5.0, timeOffset, 0 );
+    timeOffset = TimeUtil.getTargetOffsetFromTimezoneString( "Atlantic Daylight Time (UTC-400)" );
+    assertEquals( -4.0, timeOffset, 0 );
+    timeOffset = TimeUtil.getTargetOffsetFromTimezoneString( "India Daylight Time (UTC+0530)" );
+    assertEquals( 5.5, timeOffset, 0 );
+    timeOffset = TimeUtil.getTargetOffsetFromTimezoneString( "Nepal Summer Time (UTC+0545)" );
+    assertEquals( 5.75, timeOffset, 0 );
+  }
+
+  @Test
+  public void getTargetOffsetFromTimezoneStringInvalidValuesTest() {
+    double timeOffset = TimeUtil.getTargetOffsetFromTimezoneString( "Eastern Daylight Time (UTC0500)" );
+    assertEquals( 0.0, timeOffset, 0 );
+    timeOffset = TimeUtil.getTargetOffsetFromTimezoneString( "Eastern Daylight Time (UTC--0500)" );
+    assertEquals( 0.0, timeOffset, 0 );
+    timeOffset = TimeUtil.getTargetOffsetFromTimezoneString( "2020-12-01T10:30:00-05:45" );
+    assertEquals( 0.0, timeOffset, 0 );
+  }
+
+  @Test
+  public void getTargetOffsetFromDateTimeStringTest() {
+    double timeOffset = TimeUtil.getTargetOffsetFromDatetimeString( "2018-02-27T07:30:00-05:00" );
+    assertEquals( -5.0, timeOffset, 0 );
+    timeOffset = TimeUtil.getTargetOffsetFromDatetimeString( "2020-12-01T10:30:00-05:45" );
+    assertEquals( -5.75, timeOffset, 0 );
+    timeOffset = TimeUtil.getTargetOffsetFromDatetimeString( "2020-12-01 10:30:00+01:00" );
+    assertEquals( 1.0, timeOffset, 0 );
+    timeOffset = TimeUtil.getTargetOffsetFromDatetimeString( "2020-12-01 10:30:00+11:30" );
+    assertEquals( 11.5, timeOffset, 0 );
+  }
+
+  @Test
+  public void getTargetOffsetFromDateTimeStringInvalidValuesTest() {
+    double timeOffset = TimeUtil.getTargetOffsetFromDatetimeString( "2018-02-27X07:30:00-05:00" );
+    assertEquals( 0.0, timeOffset, 0 );
+    timeOffset = TimeUtil.getTargetOffsetFromDatetimeString( "2020-12T10:30:00-05:45" );
+    assertEquals( 0.0, timeOffset, 0 );
+    timeOffset = TimeUtil.getTargetOffsetFromDatetimeString( "2020-12-01 10:30:00+01" );
+    assertEquals( 0.0, timeOffset, 0 );
+    timeOffset = TimeUtil.getTargetOffsetFromDatetimeString( "Eastern Daylight Time (UTC-0500)" );
+    assertEquals( 0.0, timeOffset, 0 );
   }
 }


### PR DESCRIPTION
@bcostahitachivantara @smmribeiro 

cherry-pick of d51f3a84c53ed9cd1e33367142789e7b90bea946 and 37757ebd8d58c6c597abd91865f9dcf78428a181 
(original PR https://github.com/pentaho/pentaho-commons-gwt-modules/pull/770)

also

cherry-pick of e9394c90d43511a4574a184ac378ea4b13703395 and 57e5894ec0ec900b28c8c4ec0866547656b93f58
(original PR https://github.com/pentaho/pentaho-commons-gwt-modules/pull/775)