### PR TITLE
[BACKLOG-35298] Calling services using absolute URLs is a requirement of every CSRF-protected call

### DIFF
--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/filechooser/FileChooser.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/filechooser/FileChooser.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002 - 2020 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002 - 2021 Hitachi Vantara..  All rights reserved.
  */
 package org.pentaho.gwt.widgets.client.filechooser;
 
@@ -50,6 +50,7 @@ import org.pentaho.gwt.widgets.client.dialogs.IDialogCallback;
 import org.pentaho.gwt.widgets.client.utils.ElementUtils;
 import org.pentaho.gwt.widgets.client.utils.string.CssUtils;
 import org.pentaho.gwt.widgets.client.utils.string.StringUtils;
+import org.pentaho.mantle.client.environment.EnvironmentHelper;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -180,11 +181,6 @@ public class FileChooser extends VerticalPanel {
     }
   }
 
-  private native String getFullyQualifiedURL()
-    /*-{
-      return $wnd.location.protocol + "//" + $wnd.location.host + $wnd.CONTEXT_PATH
-    }-*/;
-
   /**
    * Load a directory by path. If it's cached, use the cache, if not load it from the server
    *
@@ -314,7 +310,7 @@ public class FileChooser extends VerticalPanel {
       filter = "*";
     }
 
-    return getFullyQualifiedURL() + "api/repo/files/" + folderId + "/tree?"
+    return EnvironmentHelper.getFullyQualifiedURL() + "api/repo/files/" + folderId + "/tree?"
         + "showHidden=" + showHiddenFiles + "&depth=" + depth + "&filter=" + filter;
   }
 
@@ -923,12 +919,4 @@ public class FileChooser extends VerticalPanel {
   public native boolean isMobileSafari()/*-{
     return (window.orientation !== undefined);
   }-*/;
-
-  public native String getWebAppRoot()/*-{
-    if ($wnd.CONTEXT_PATH) {
-      return $wnd.CONTEXT_PATH;
-    }
-    return "";
-  }-*/;
-
 }

--- a/widgets/src/main/java/org/pentaho/mantle/client/commands/AbstractCommand.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/commands/AbstractCommand.java
@@ -17,7 +17,6 @@
 
 package org.pentaho.mantle.client.commands;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.http.client.Request;
 import com.google.gwt.http.client.RequestBuilder;
 import com.google.gwt.http.client.RequestCallback;
@@ -27,11 +26,10 @@ import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
-
 import org.pentaho.gwt.widgets.client.dialogs.IDialogCallback;
 import org.pentaho.gwt.widgets.client.dialogs.MessageDialogBox;
-import org.pentaho.mantle.client.dialogs.scheduling.ScheduleHelper;
 import org.pentaho.mantle.client.messages.Messages;
+import org.pentaho.mantle.client.environment.EnvironmentHelper;
 import org.pentaho.mantle.login.client.MantleLoginDialog;
 
 /**
@@ -39,9 +37,8 @@ import org.pentaho.mantle.login.client.MantleLoginDialog;
  * method first check whether the user is authenticated or not and then if the user is authentication is performs
  * the command described in the performOperation method, otherwise the login screen will be displayed back to the
  * user
- * 
+ *
  * @author rmansoor
- * 
  */
 public abstract class AbstractCommand implements Command {
 
@@ -50,9 +47,8 @@ public abstract class AbstractCommand implements Command {
   /**
    * Checks if the user is logged in, if the user is then it perform operation other wise user if ask to perform
    * the login operation again
-   * 
-   * @param feedback
-   *          if the feedback needs to be sent back to the caller. Not used currently
+   *
+   * @param feedback if the feedback needs to be sent back to the caller. Not used currently
    */
   public void execute( final boolean feedback ) {
     execute( (CommandResultCallback) null, feedback );
@@ -63,9 +59,8 @@ public abstract class AbstractCommand implements Command {
    * the login operation again.
    * <p>
    * After the operation is executed, the CommandCallback object receives an afterExecute() notification.
-   * 
-   * @param commandCallback
-   *          CommandCallback object to receive execution notification.
+   *
+   * @param commandCallback CommandCallback object to receive execution notification.
    */
   public void execute( CommandCallback commandCallback ) {
     execute( commandCallback, false );
@@ -77,10 +72,8 @@ public abstract class AbstractCommand implements Command {
    * <p>
    * After the operation is executed, the CommandCallback object receives an afterExecute() notification.
    *
-   * @param commandCallback
-   *          CommandCallback object to receive execution notification.
-   * @param feedback
-   *          if the feedback needs to be sent back to the caller. Not used currently
+   * @param commandCallback CommandCallback object to receive execution notification.
+   * @param feedback        if the feedback needs to be sent back to the caller. Not used currently
    */
   public void execute( final CommandCallback commandCallback, final boolean feedback ) {
     execute( createResultCallback( commandCallback ), feedback );
@@ -91,17 +84,15 @@ public abstract class AbstractCommand implements Command {
    * the login operation again.
    * <p>
    * After the operation is executed, the CommandResultCallback object receives an afterExecute() notification.
-   * 
-   * @param commandResultCallback
-   *          CommandResultCallback object to receive execution notification.
-   * @param feedback
-   *          if the feedback needs to be sent back to the caller. Not used currently
+   *
+   * @param commandResultCallback CommandResultCallback object to receive execution notification.
+   * @param feedback              if the feedback needs to be sent back to the caller. Not used currently
    */
   public void execute( final CommandResultCallback commandResultCallback, final boolean feedback ) {
     this.commandResultCallback = commandResultCallback;
 
     try {
-      final String url = ScheduleHelper.getFullyQualifiedURL() + "api/mantle/isAuthenticated"; //$NON-NLS-1$
+      final String url = EnvironmentHelper.getFullyQualifiedURL() + "api/mantle/isAuthenticated"; //$NON-NLS-1$
       RequestBuilder requestBuilder = new RequestBuilder( RequestBuilder.GET, url );
       requestBuilder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );
       requestBuilder.setHeader( "accept", "text/plain" );
@@ -129,7 +120,7 @@ public abstract class AbstractCommand implements Command {
   public void execute() {
     this.commandResultCallback = null;
     try {
-      final String url = ScheduleHelper.getFullyQualifiedURL() + "api/mantle/isAuthenticated"; //$NON-NLS-1$
+      final String url = EnvironmentHelper.getFullyQualifiedURL() + "api/mantle/isAuthenticated"; //$NON-NLS-1$
       RequestBuilder requestBuilder = new RequestBuilder( RequestBuilder.GET, url );
       requestBuilder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );
       requestBuilder.setHeader( "accept", "text/plain" );
@@ -154,19 +145,18 @@ public abstract class AbstractCommand implements Command {
    * the execute method is being invoked otherwise error dialog is being display. On clicking ok button on the
    * dialog box, login screen is displayed again and process is repeated until the user click cancel or user is
    * successfully authenticated
-   * 
-   * @param feedback
-   *          if the feedback needs to be sent back to the caller. Not used currently
+   *
+   * @param feedback if the feedback needs to be sent back to the caller. Not used currently
    */
   private void doLogin( final boolean feedback ) {
     MantleLoginDialog.performLogin( new AsyncCallback<Boolean>() {
 
       public void onFailure( Throwable caught ) {
         MessageDialogBox dialogBox =
-            new MessageDialogBox( Messages.getString( "error" ), Messages.getString( "invalidLogin" ), false, false,
-                true ) {
+          new MessageDialogBox( Messages.getString( "error" ), Messages.getString( "invalidLogin" ), false, false,
+            true ) {
 
-            }; //$NON-NLS-1$ //$NON-NLS-2$
+          }; //$NON-NLS-1$ //$NON-NLS-2$
 
         dialogBox.setCallback( new IDialogCallback() {
           public void cancelPressed() {
@@ -195,7 +185,7 @@ public abstract class AbstractCommand implements Command {
    * the execute method is being invoked other wise error dialog is being display. On clicking ok button on the
    * dialog box, login screen is displayed again and process is repeated until the user click cancel or user is
    * successfully authenticated
-   * */
+   */
   private void doLogin() {
     Timer t = new Timer() {
 
@@ -206,8 +196,9 @@ public abstract class AbstractCommand implements Command {
 
           public void onFailure( Throwable caught ) {
             MessageDialogBox dialogBox =
-                new MessageDialogBox(
-                    Messages.getString( "error" ), Messages.getString( "invalidLogin" ), false, false, true ); //$NON-NLS-1$ //$NON-NLS-2$
+              new MessageDialogBox(
+                Messages.getString( "error" ), Messages.getString( "invalidLogin" ), false, false,
+                true ); //$NON-NLS-1$ //$NON-NLS-2$
             dialogBox.setCallback( new IDialogCallback() {
               public void cancelPressed() {
               }
@@ -233,36 +224,31 @@ public abstract class AbstractCommand implements Command {
   /**
    * This is an abstract method which the extending class with implement with logic of performing specific
    * operation
-   * 
-   * */
+   */
   protected abstract void performOperation();
 
   /**
    * This is an abstract method which the extending class with implement with logic of performing specific
    * operation
-   * 
-   * @param feedback
-   *          if the feedback needs to be sent back to the caller. Not used currently
-   * 
-   * */
+   *
+   * @param feedback if the feedback needs to be sent back to the caller. Not used currently
+   */
   protected abstract void performOperation( final boolean feedback );
 
   /**
    * Performs the operation asynchronously.
-   *
+   * <p>
    * The default implementation calls the synchronous method, performOperation and then calls callback.onSuccess.
    * It does not handle errors, to preserve full compatibility.
-   *
+   * <p>
    * Actual implementations should handle all states and, ideally, should not throw.
    *
-   * @param feedback
-   *          if the feedback needs to be sent back to the caller. Not used currently
-   * @param callback
-   *         when not null, allows the result of the operation to be reported to the caller.
+   * @param feedback if the feedback needs to be sent back to the caller. Not used currently
+   * @param callback when not null, allows the result of the operation to be reported to the caller.
    */
   protected void performOperationAsync( final boolean feedback, CommandResultCallback callback ) {
 
-    performOperation(feedback);
+    performOperation( feedback );
 
     if ( callback != null ) {
       callback.onSuccess();
@@ -289,7 +275,7 @@ public abstract class AbstractCommand implements Command {
       }
 
       @Override
-      public void onError(Throwable error) {
+      public void onError( Throwable error ) {
       }
     };
   }

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/FolderTree.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/FolderTree.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.mantle.client.dialogs.folderchooser;
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-import com.google.gwt.core.client.GWT;
 import org.pentaho.gwt.widgets.client.filechooser.JsonToRepositoryFileTreeConverter;
 import org.pentaho.gwt.widgets.client.filechooser.RepositoryFile;
 import org.pentaho.gwt.widgets.client.filechooser.RepositoryFileTree;
@@ -31,7 +30,6 @@ import org.pentaho.gwt.widgets.client.utils.ElementUtils;
 import org.pentaho.gwt.widgets.client.utils.string.StringTokenizer;
 import org.pentaho.gwt.widgets.client.utils.string.StringUtils;
 import org.pentaho.mantle.client.dialogs.WaitPopup;
-import org.pentaho.mantle.client.dialogs.scheduling.ScheduleHelper;
 import org.pentaho.mantle.client.messages.Messages;
 
 import com.google.gwt.dom.client.NativeEvent;
@@ -54,6 +52,7 @@ import com.google.gwt.user.client.ui.FocusPanel;
 import com.google.gwt.user.client.ui.Tree;
 import com.google.gwt.user.client.ui.TreeItem;
 import com.google.gwt.user.client.ui.Widget;
+import org.pentaho.mantle.client.environment.EnvironmentHelper;
 
 public class FolderTree extends Tree /*implements IRepositoryFileTreeListener, UserSettingsLoadedEventHandler,
     IRepositoryFileProvider*/ {
@@ -175,7 +174,7 @@ public class FolderTree extends Tree /*implements IRepositoryFileTreeListener, U
     // such as busy cursor or tree loading indicators)
     beforeFetchRepositoryFileTree();
     RequestBuilder builder = null;
-    String url = ScheduleHelper.getFullyQualifiedURL() + "api/repo/files/:/tree?"; //$NON-NLS-1$
+    String url = EnvironmentHelper.getFullyQualifiedURL() + "api/repo/files/:/tree?"; //$NON-NLS-1$
     if ( depth == null ) {
       depth = -1;
     }
@@ -207,7 +206,7 @@ public class FolderTree extends Tree /*implements IRepositoryFileTreeListener, U
               new JsonToRepositoryFileTreeConverter( response.getText() );
           final RepositoryFileTree fileTree = converter.getTree();
 
-          String deletedFilesUrl = ScheduleHelper.getFullyQualifiedURL() + "api/repo/files/deleted?ts=" + System.currentTimeMillis();
+          String deletedFilesUrl = EnvironmentHelper.getFullyQualifiedURL() + "api/repo/files/deleted?ts=" + System.currentTimeMillis();
           RequestBuilder deletedFilesRequestBuilder = new RequestBuilder( RequestBuilder.GET, deletedFilesUrl );
           deletedFilesRequestBuilder.setHeader( "Accept", "application/json" );
           deletedFilesRequestBuilder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );
@@ -422,7 +421,7 @@ public class FolderTree extends Tree /*implements IRepositoryFileTreeListener, U
   }
 
   /**
-   * 
+   *
    */
   private void fixLeafNodes() {
     List<FolderTreeItem> allNodes = getAllNodes();
@@ -717,7 +716,7 @@ public class FolderTree extends Tree /*implements IRepositoryFileTreeListener, U
 
   private static String refreshHomeFolder() {
 
-    final String userHomeDirUrl = GWT.getHostPageBaseURL() + "api/session/userWorkspaceDir";
+    final String userHomeDirUrl = EnvironmentHelper.getFullyQualifiedURL() + "api/session/userWorkspaceDir";
     final RequestBuilder builder = new RequestBuilder( RequestBuilder.GET, userHomeDirUrl );
 
     try {

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/LeafItemWidget.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/LeafItemWidget.java
@@ -12,17 +12,16 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.mantle.client.dialogs.folderchooser;
-
-import org.pentaho.mantle.client.dialogs.scheduling.ScheduleHelper;
 
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Label;
+import org.pentaho.mantle.client.environment.EnvironmentHelper;
 
 /**
  * @author wseyler
@@ -36,7 +35,7 @@ public class LeafItemWidget extends Composite {
     HorizontalPanel widget = new HorizontalPanel();
     initWidget( widget );
 
-    leafImage = new Image( ScheduleHelper.getFullyQualifiedURL() + "content/common-ui/resources/themes/images/spacer.gif" ); //ImageUtil.getThemeableImage( styleName );
+    leafImage = new Image( EnvironmentHelper.getFullyQualifiedURL() + "content/common-ui/resources/themes/images/spacer.gif" ); //ImageUtil.getThemeableImage( styleName );
     for ( String style : styleName ) {
       leafImage.addStyleName( style );
     }

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/NewFolderCommand.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/NewFolderCommand.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2020 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.mantle.client.dialogs.folderchooser;
@@ -26,7 +26,6 @@ import org.pentaho.gwt.widgets.client.ui.ICallback;
 import org.pentaho.gwt.widgets.client.utils.NameUtils;
 import org.pentaho.gwt.widgets.client.utils.string.StringUtils;
 import org.pentaho.mantle.client.commands.AbstractCommand;
-import org.pentaho.mantle.client.dialogs.scheduling.ScheduleHelper;
 import org.pentaho.mantle.client.messages.Messages;
 
 import com.google.gwt.http.client.Request;
@@ -38,11 +37,12 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.VerticalPanel;
+import org.pentaho.mantle.client.environment.EnvironmentHelper;
 
 public class NewFolderCommand extends AbstractCommand {
   private static final String ERROR = "error";
   private String solutionPath = null;
-  private String contextURL = ScheduleHelper.getFullyQualifiedURL();
+  private String contextURL = EnvironmentHelper.getFullyQualifiedURL();
 
   private RepositoryFile parentFolder;
 

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/SelectFolderDialog.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/SelectFolderDialog.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.mantle.client.dialogs.folderchooser;
@@ -23,7 +23,6 @@ import org.pentaho.gwt.widgets.client.filechooser.RepositoryFileTree;
 import org.pentaho.gwt.widgets.client.toolbar.Toolbar;
 import org.pentaho.gwt.widgets.client.toolbar.ToolbarButton;
 import org.pentaho.gwt.widgets.client.ui.ICallback;
-import org.pentaho.mantle.client.dialogs.scheduling.ScheduleHelper;
 import org.pentaho.mantle.client.messages.Messages;
 
 import com.google.gwt.dom.client.Style.Unit;
@@ -36,6 +35,7 @@ import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.TreeItem;
 import com.google.gwt.user.client.ui.VerticalPanel;
+import org.pentaho.mantle.client.environment.EnvironmentHelper;
 
 public class SelectFolderDialog extends PromptDialogBox {
 
@@ -82,7 +82,7 @@ public class SelectFolderDialog extends PromptDialogBox {
     bar.add( new Label( Messages.getString( "newFolderColon" ), false ) );
     bar.add( Toolbar.GLUE );
 
-    Image image = new Image( ScheduleHelper.getFullyQualifiedURL() + "content/common-ui/resources/themes/images/spacer.gif" );
+    Image image = new Image( EnvironmentHelper.getFullyQualifiedURL() + "content/common-ui/resources/themes/images/spacer.gif" );
     image.addStyleName( "icon-small" );
     image.addStyleName( "pentaho-addbutton" );
     ToolbarButton add = new ToolbarButton( image ); //ImageUtil.getThemeableImage( "icon-small", "pentaho-addbutton" ) );

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/NewScheduleDialog.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/NewScheduleDialog.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.mantle.client.dialogs.scheduling;
@@ -29,6 +29,7 @@ import org.pentaho.gwt.widgets.client.wizards.AbstractWizardDialog.ScheduleDialo
 import org.pentaho.mantle.client.dialogs.WaitPopup;
 import org.pentaho.mantle.client.dialogs.folderchooser.SelectFolderDialog;
 import org.pentaho.mantle.client.messages.Messages;
+import org.pentaho.mantle.client.environment.EnvironmentHelper;
 import org.pentaho.mantle.client.workspace.JsJob;
 import org.pentaho.mantle.client.workspace.JsJobParam;
 
@@ -314,11 +315,11 @@ public class NewScheduleDialog extends PromptDialogBox {
 
     if ( ( urlPath != null ) && ( urlPath.endsWith( "xaction" ) ) ) {
       isXAction = true;
-      scheduleFileRequestBuilder = new RequestBuilder( RequestBuilder.GET, ScheduleHelper.getFullyQualifiedURL() + "api/repos/" + urlPath
+      scheduleFileRequestBuilder = new RequestBuilder( RequestBuilder.GET, EnvironmentHelper.getFullyQualifiedURL() + "api/repos/" + urlPath
           + "/parameterUi" );
     } else {
       isXAction = false;
-      scheduleFileRequestBuilder = new RequestBuilder( RequestBuilder.GET, ScheduleHelper.getFullyQualifiedURL() + "api/repo/files/" + urlPath
+      scheduleFileRequestBuilder = new RequestBuilder( RequestBuilder.GET, EnvironmentHelper.getFullyQualifiedURL() + "api/repo/files/" + urlPath
           + "/parameterizable" );
     }
 

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/OutputLocationUtils.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/OutputLocationUtils.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.mantle.client.dialogs.scheduling;
@@ -26,6 +26,7 @@ import com.google.gwt.http.client.RequestCallback;
 import com.google.gwt.http.client.RequestException;
 import com.google.gwt.http.client.Response;
 import com.google.gwt.user.client.Command;
+import org.pentaho.mantle.client.environment.EnvironmentHelper;
 
 /**
  * @author Rowell Belen
@@ -42,7 +43,7 @@ public class OutputLocationUtils {
     }
 
     final String outputLocationPath = NameUtils.encodeRepositoryPath( outputLocation );
-    final String url = ScheduleHelper.getFullyQualifiedURL() + "api/repo/files/" + outputLocationPath + "/tree?depth=1"; //$NON-NLS-1$
+    final String url = EnvironmentHelper.getFullyQualifiedURL() + "api/repo/files/" + outputLocationPath + "/tree?depth=1"; //$NON-NLS-1$
     RequestBuilder builder = new RequestBuilder( RequestBuilder.GET, url );
     // This header is required to force Internet Explorer to not cache values from the GET response.
     builder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleEditor.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleEditor.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.mantle.client.dialogs.scheduling;
@@ -68,6 +68,7 @@ import com.google.gwt.user.client.ui.UIObject;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.user.datepicker.client.CalendarUtil;
+import org.pentaho.mantle.client.environment.EnvironmentHelper;
 
 /**
  * @author Steven Barkdull
@@ -520,7 +521,7 @@ public class ScheduleEditor extends VerticalPanel implements IChangeHandler {
 
   private void populateTimeZonePicker() {
 
-    String url = ScheduleHelper.getFullyQualifiedURL() + "api/system/timezones"; //$NON-NLS-1$
+    String url = EnvironmentHelper.getFullyQualifiedURL() + "api/system/timezones"; //$NON-NLS-1$
     RequestBuilder timeZonesRequest = new RequestBuilder( RequestBuilder.GET, url );
     timeZonesRequest.setHeader( "accept", "application/json" ); //$NON-NLS-1$ //$NON-NLS-2$
     timeZonesRequest.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleHelper.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleHelper.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.mantle.client.dialogs.scheduling;
@@ -26,6 +26,7 @@ import org.pentaho.mantle.client.commands.AbstractCommand;
 import org.pentaho.mantle.client.events.EventBusUtil;
 import org.pentaho.mantle.client.events.SolutionFileActionEvent;
 import org.pentaho.mantle.client.messages.Messages;
+import org.pentaho.mantle.client.environment.EnvironmentHelper;
 import org.pentaho.mantle.client.workspace.JsJob;
 import org.pentaho.mantle.login.client.MantleLoginDialog;
 
@@ -64,7 +65,7 @@ public class ScheduleHelper {
     event.setAction( ScheduleHelper.class.getName() );
     try {
 
-      final String url = ScheduleHelper.getFullyQualifiedURL() + "api/mantle/isAuthenticated"; //$NON-NLS-1$
+      final String url = EnvironmentHelper.getFullyQualifiedURL() + "api/mantle/isAuthenticated"; //$NON-NLS-1$
       RequestBuilder requestBuilder = new RequestBuilder( RequestBuilder.GET, url );
       requestBuilder.setHeader( "accept", "text/plain" );
       requestBuilder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );
@@ -138,7 +139,7 @@ public class ScheduleHelper {
       protected void performOperation() {
 
         // hit the server and check: isScheduleAllowed
-        final String url = ScheduleHelper.getFullyQualifiedURL() + "api/scheduler/isScheduleAllowed?id=" + repositoryFile.getId(); //$NON-NLS-1$
+        final String url = EnvironmentHelper.getFullyQualifiedURL() + "api/scheduler/isScheduleAllowed?id=" + repositoryFile.getId(); //$NON-NLS-1$
         RequestBuilder requestBuilder = new RequestBuilder( RequestBuilder.GET, url );
         requestBuilder.setHeader( "accept", "text/plain" );
         requestBuilder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );
@@ -246,10 +247,10 @@ public class ScheduleHelper {
 
     if ( editJob == null || editJob.getJobId() == null ) {
       scheduleFileRequestBuilder =
-          new RequestBuilder( RequestBuilder.POST, getFullyQualifiedURL() + JOB_SCHEDULER_URL );
+          new RequestBuilder( RequestBuilder.POST, EnvironmentHelper.getFullyQualifiedURL() + JOB_SCHEDULER_URL );
     } else {
       scheduleFileRequestBuilder =
-        new RequestBuilder( RequestBuilder.POST, getFullyQualifiedURL() + UPDATE_JOB_SCHEDULER_URL );
+        new RequestBuilder( RequestBuilder.POST, EnvironmentHelper.getFullyQualifiedURL() + UPDATE_JOB_SCHEDULER_URL );
       if ( null != requestPayload ) {
         requestPayload.put( "jobId", new JSONString( editJob.getJobId() ) );
       }
@@ -261,6 +262,15 @@ public class ScheduleHelper {
     return scheduleFileRequestBuilder;
   }
 
+  /**
+   * Gets the fully qualified base URL of the Pentaho server environment.
+   *
+   * This version does not support embedding scenarios.
+   * Additionally, it is tied to the Pentaho scheduler.
+   *
+   * @deprecated Use {@link EnvironmentHelper#getFullyQualifiedURL()} instead.
+   */
+  @Deprecated
   public static native String getFullyQualifiedURL()
   /*-{
     return $wnd.location.protocol + "//" + $wnd.location.host + $wnd.CONTEXT_PATH

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleOutputLocationDialogExecutor.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleOutputLocationDialogExecutor.java
@@ -38,6 +38,7 @@ import com.google.gwt.json.client.JSONNumber;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONString;
 import com.google.gwt.json.client.JSONValue;
+import org.pentaho.mantle.client.environment.EnvironmentHelper;
 
 public class ScheduleOutputLocationDialogExecutor {
   private String solutionPath = null;
@@ -214,11 +215,11 @@ public class ScheduleOutputLocationDialogExecutor {
     RequestBuilder scheduleFileRequestBuilder = null;
     if ( ( urlPath != null ) && ( urlPath.endsWith( "xaction" ) ) ) {
       scheduleFileRequestBuilder =
-          new RequestBuilder( RequestBuilder.GET, ScheduleHelper.getFullyQualifiedURL() + "api/repos/" + urlPath
+          new RequestBuilder( RequestBuilder.GET, EnvironmentHelper.getFullyQualifiedURL() + "api/repos/" + urlPath
               + "/parameterUi" );
     } else {
       scheduleFileRequestBuilder =
-          new RequestBuilder( RequestBuilder.GET, ScheduleHelper.getFullyQualifiedURL() + "api/repo/files/" + urlPath
+          new RequestBuilder( RequestBuilder.GET, EnvironmentHelper.getFullyQualifiedURL() + "api/repo/files/" + urlPath
               + "/parameterizable" );
     }
     scheduleFileRequestBuilder.setHeader( "accept", "text/plain" ); //$NON-NLS-1$ //$NON-NLS-2$
@@ -283,7 +284,7 @@ public class ScheduleOutputLocationDialogExecutor {
             final boolean hasParams = hasParameters( responseMessage, isXAction );
 
             RequestBuilder emailValidRequest =
-                new RequestBuilder( RequestBuilder.GET, ScheduleHelper.getFullyQualifiedURL()
+                new RequestBuilder( RequestBuilder.GET, EnvironmentHelper.getFullyQualifiedURL()
                     + "api/emailconfig/isValid" ); //$NON-NLS-1$
             emailValidRequest.setHeader( "accept", "text/plain" ); //$NON-NLS-1$ //$NON-NLS-2$
             emailValidRequest.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );
@@ -318,7 +319,7 @@ public class ScheduleOutputLocationDialogExecutor {
 
                       // just run it
                       RequestBuilder scheduleFileRequestBuilder =
-                          new RequestBuilder( RequestBuilder.POST, ScheduleHelper.getFullyQualifiedURL()
+                          new RequestBuilder( RequestBuilder.POST, EnvironmentHelper.getFullyQualifiedURL()
                               + "api/scheduler/job" ); //$NON-NLS-1$
                       scheduleFileRequestBuilder.setHeader( "Content-Type", "application/json" ); //$NON-NLS-1$//$NON-NLS-2$
                       scheduleFileRequestBuilder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleParamsDialog.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleParamsDialog.java
@@ -23,6 +23,7 @@ import org.pentaho.gwt.widgets.client.utils.NameUtils;
 import org.pentaho.gwt.widgets.client.wizards.AbstractWizardDialog;
 import org.pentaho.gwt.widgets.client.wizards.IWizardPanel;
 import org.pentaho.mantle.client.messages.Messages;
+import org.pentaho.mantle.client.environment.EnvironmentHelper;
 import org.pentaho.mantle.client.workspace.JsJob;
 import org.pentaho.mantle.client.workspace.JsJobParam;
 import org.pentaho.mantle.login.client.MantleLoginDialog;
@@ -123,7 +124,7 @@ public class ScheduleParamsDialog extends AbstractWizardDialog {
         urlParams += jparams.get( i ).getName() + "=" + URL.encodeQueryString( jparams.get( i ).getValue().trim() );
       }
     }
-    setParametersUrl( ScheduleHelper.getFullyQualifiedURL() + "api/repos/" + urlPath + "/parameterUi" + urlParams ); //$NON-NLS-1$ //$NON-NLS-2$
+    setParametersUrl( EnvironmentHelper.getFullyQualifiedURL() + "api/repos/" + urlPath + "/parameterUi" + urlParams ); //$NON-NLS-1$ //$NON-NLS-2$
     wizardDeckPanel.setHeight( "100%" ); //$NON-NLS-1$
 
     wizardDeckPanel.getElement().getParentElement().addClassName( "schedule-dialog-content" );
@@ -224,7 +225,7 @@ public class ScheduleParamsDialog extends AbstractWizardDialog {
   private void showScheduleEmailDialog( final JSONArray scheduleParams ) {
 
     try {
-      final String url = ScheduleHelper.getFullyQualifiedURL() + "api/mantle/isAuthenticated"; //$NON-NLS-1$
+      final String url = EnvironmentHelper.getFullyQualifiedURL() + "api/mantle/isAuthenticated"; //$NON-NLS-1$
       RequestBuilder requestBuilder = new RequestBuilder( RequestBuilder.GET, url );
       requestBuilder.setHeader( "accept", "text/plain" );
       requestBuilder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );
@@ -322,7 +323,7 @@ public class ScheduleParamsDialog extends AbstractWizardDialog {
                       + "=" +  URL.encodeQueryString( stringValueArr.get( j ).toString().replace( "\"", "" ) );
         }
       }
-      setParametersUrl( ScheduleHelper.getFullyQualifiedURL() + "api/repos/" + urlPath + "/parameterUi" + urlParams ); //$NON-NLS-1$ //$NON-NLS-2$
+      setParametersUrl( EnvironmentHelper.getFullyQualifiedURL() + "api/repos/" + urlPath + "/parameterUi" + urlParams ); //$NON-NLS-1$ //$NON-NLS-2$
     }
     super.center();
   }

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
@@ -37,6 +37,7 @@ import org.pentaho.mantle.client.dialogs.scheduling.RecurrenceEditor.YearlyRecur
 import org.pentaho.mantle.client.dialogs.scheduling.ScheduleEditor.DurationValues;
 import org.pentaho.mantle.client.dialogs.scheduling.ScheduleEditor.ScheduleType;
 import org.pentaho.mantle.client.messages.Messages;
+import org.pentaho.mantle.client.environment.EnvironmentHelper;
 import org.pentaho.mantle.client.workspace.BlockoutPanel;
 import org.pentaho.mantle.client.workspace.JsBlockStatus;
 import org.pentaho.mantle.client.workspace.JsJob;
@@ -176,7 +177,7 @@ public class ScheduleRecurrenceDialog extends AbstractWizardDialog {
     this.overwriteFile = overwriteFile;
     scheduleEditorWizardPanel = new ScheduleEditorWizardPanel( getDialogType() );
     scheduleEditor = scheduleEditorWizardPanel.getScheduleEditor();
-    String url = ScheduleHelper.getFullyQualifiedURL() + "api/scheduler/blockout/hasblockouts?ts=" + System.currentTimeMillis(); //$NON-NLS-1$
+    String url = EnvironmentHelper.getFullyQualifiedURL() + "api/scheduler/blockout/hasblockouts?ts=" + System.currentTimeMillis(); //$NON-NLS-1$
     RequestBuilder hasBlockoutsRequest = new RequestBuilder( RequestBuilder.GET, url );
     hasBlockoutsRequest.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );
     hasBlockoutsRequest.setHeader( "accept", "text/plain" );
@@ -690,7 +691,7 @@ public class ScheduleRecurrenceDialog extends AbstractWizardDialog {
   }
 
   protected boolean addBlockoutPeriod( final JSONObject schedule, final JsJobTrigger trigger, String urlSuffix ) {
-    String url = ScheduleHelper.getFullyQualifiedURL() + "api/scheduler/blockout/" + urlSuffix; //$NON-NLS-1$
+    String url = EnvironmentHelper.getFullyQualifiedURL() + "api/scheduler/blockout/" + urlSuffix; //$NON-NLS-1$
 
     RequestBuilder addBlockoutPeriodRequest = new RequestBuilder( RequestBuilder.POST, url );
     addBlockoutPeriodRequest.setHeader( "accept", "text/plain" ); //$NON-NLS-1$ //$NON-NLS-2$
@@ -785,7 +786,7 @@ public class ScheduleRecurrenceDialog extends AbstractWizardDialog {
    * @param trigger
    */
   protected void verifyBlockoutConflict( final JSONObject schedule, final JsJobTrigger trigger ) {
-    String url = ScheduleHelper.getFullyQualifiedURL() + "api/scheduler/blockout/blockstatus"; //$NON-NLS-1$
+    String url = EnvironmentHelper.getFullyQualifiedURL() + "api/scheduler/blockout/blockstatus"; //$NON-NLS-1$
 
     RequestBuilder blockoutConflictRequest = new RequestBuilder( RequestBuilder.POST, url );
     blockoutConflictRequest.setHeader( "accept", "application/json" ); //$NON-NLS-1$ //$NON-NLS-2$
@@ -936,7 +937,7 @@ public class ScheduleRecurrenceDialog extends AbstractWizardDialog {
 
   private void showScheduleEmailDialog( final JSONObject schedule ) {
     try {
-      final String url = ScheduleHelper.getFullyQualifiedURL() + "api/mantle/isAuthenticated"; //$NON-NLS-1$
+      final String url = EnvironmentHelper.getFullyQualifiedURL() + "api/mantle/isAuthenticated"; //$NON-NLS-1$
       RequestBuilder requestBuilder = new RequestBuilder( RequestBuilder.GET, url );
       requestBuilder.setHeader( "accept", "text/plain" ); //$NON-NLS-1$ //$NON-NLS-2$
       requestBuilder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );
@@ -981,7 +982,7 @@ public class ScheduleRecurrenceDialog extends AbstractWizardDialog {
 
   private void showScheduleParamsDialog( final JsJobTrigger trigger, final JSONObject schedule ) {
     try {
-      final String url = ScheduleHelper.getFullyQualifiedURL() + "api/mantle/isAuthenticated"; //$NON-NLS-1$
+      final String url = EnvironmentHelper.getFullyQualifiedURL() + "api/mantle/isAuthenticated"; //$NON-NLS-1$
       RequestBuilder requestBuilder = new RequestBuilder( RequestBuilder.GET, url );
       requestBuilder.setHeader( "accept", "text/plain" ); //$NON-NLS-1$ //$NON-NLS-2$
       requestBuilder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );

--- a/widgets/src/main/java/org/pentaho/mantle/client/environment/EnvironmentHelper.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/environment/EnvironmentHelper.java
@@ -1,0 +1,42 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2021 Hitachi Vantara..  All rights reserved.
+ */
+
+package org.pentaho.mantle.client.environment;
+
+public class EnvironmentHelper {
+  private EnvironmentHelper() {
+    // Disallow instantiation.
+  }
+
+  /**
+   * Gets the context path of the Pentaho application, relative to its web server.
+   * Example: <code>/pentaho/</code>
+   * @return The context path of the Pentaho application.
+   */
+  public static native String getContextPath()/*-{
+    return $wnd.CONTEXT_PATH || "";
+  }-*/;
+
+  /**
+   * Gets the fully qualified base URL of the Pentaho server environment.
+   * Example: <code>http://locahost:8080/pentaho/</code>
+   * @return The fully qualified base URL.
+   */
+  public static native String getFullyQualifiedURL()/*-{
+    return $wnd.FULL_QUALIFIED_URL || "";
+  }-*/;
+}

--- a/widgets/src/main/java/org/pentaho/mantle/login/client/MantleLoginDialog.java
+++ b/widgets/src/main/java/org/pentaho/mantle/login/client/MantleLoginDialog.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.mantle.login.client;
@@ -45,7 +45,7 @@ import org.pentaho.gwt.widgets.client.dialogs.IDialogCallback;
 import org.pentaho.gwt.widgets.client.dialogs.MessageDialogBox;
 import org.pentaho.gwt.widgets.client.dialogs.PromptDialogBox;
 import org.pentaho.gwt.widgets.client.utils.string.StringTokenizer;
-import org.pentaho.mantle.client.dialogs.scheduling.ScheduleHelper;
+import org.pentaho.mantle.client.environment.EnvironmentHelper;
 import org.pentaho.mantle.login.client.messages.Messages;
 
 import java.util.Date;
@@ -86,7 +86,7 @@ public class MantleLoginDialog extends PromptDialogBox {
           public void onResponseReceived( Request request, Response response ) {
 
             try {
-              final String url = ScheduleHelper.getFullyQualifiedURL() + "api/mantle/isAuthenticated"; //$NON-NLS-1$
+              final String url = EnvironmentHelper.getFullyQualifiedURL() + "api/mantle/isAuthenticated"; //$NON-NLS-1$
               RequestBuilder requestBuilder = new RequestBuilder( RequestBuilder.GET, url );
               requestBuilder.setHeader( "accept", "text/plain" );
               requestBuilder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );
@@ -166,7 +166,7 @@ public class MantleLoginDialog extends PromptDialogBox {
   public static void performLogin( final AsyncCallback<Boolean> callback ) {
     // let's only login if we are not actually logged in
     try {
-      final String url = ScheduleHelper.getFullyQualifiedURL() + "api/mantle/isAuthenticated"; //$NON-NLS-1$
+      final String url = EnvironmentHelper.getFullyQualifiedURL() + "api/mantle/isAuthenticated"; //$NON-NLS-1$
       RequestBuilder requestBuilder = new RequestBuilder( RequestBuilder.GET, url );
       requestBuilder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );
       requestBuilder.setHeader( "accept", "text/plain" );

--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/Widgets.gwt.xml
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/Widgets.gwt.xml
@@ -11,6 +11,7 @@
 
       <inherits name='com.allen_sauer.gwt.dnd.gwt-dnd'/>
       <inherits name="org.adamtacy.GWTEffects"/>
+      <inherits name="org.pentaho.mantle.client.environment.Environment"/>
 
       <!-- Inherit the default GWT style sheet.  You can change       -->
       <!-- the theme of your GWT application by uncommenting          -->

--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/client/filechooser/FileChooser.gwt.xml
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/client/filechooser/FileChooser.gwt.xml
@@ -6,7 +6,7 @@
   <inherits name="com.google.gwt.xml.XML"/>
 
   <inherits name="org.pentaho.gwt.widgets.Widgets"/>
-
+  <inherits name="org.pentaho.mantle.client.environment.Environment"/>
 
   <!-- Inherit the default GWT style sheet.  You can change       -->
   <!-- the theme of your GWT application by uncommenting          -->

--- a/widgets/src/main/resources/org/pentaho/mantle/client/environment/Environment.gwt.xml
+++ b/widgets/src/main/resources/org/pentaho/mantle/client/environment/Environment.gwt.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module>
+  <source path=""/>
+
+  <!-- Inherit the core Web Toolkit stuff. -->
+  <inherits name='com.google.gwt.user.User'/>
+</module>


### PR DESCRIPTION
- Changed all services using CONTEXT_PATH to use the new EnvironmentHelper.getFullyQualifiedURL method.

Depends on https://github.com/pentaho/maven-parent-poms/pull/301.

See PR set: https://github.com/pentaho/security-web/pull/10.

@bennychow, @ddiroma please review and merge.