### PR TITLE
[BACKLOG-35428] Unable to Schedule reports when Pentaho Server running in a different machine that Browser

### DIFF
--- a/widgets/src/main/java/org/pentaho/mantle/client/environment/EnvironmentHelper.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/environment/EnvironmentHelper.java
@@ -37,6 +37,6 @@ public class EnvironmentHelper {
    * @return The fully qualified base URL.
    */
   public static native String getFullyQualifiedURL()/*-{
-    return $wnd.FULL_QUALIFIED_URL || "";
+    return $wnd.location.protocol + "//" + $wnd.location.host + $wnd.CONTEXT_PATH;
   }-*/;
 }


### PR DESCRIPTION
Not using the `FULL_QUALIFIED_URL` global variable anymore. Its value is not always reliable and depends on the configuring `fully-qualified-server-url` in the `server.properties` file.
Instead, now relying only on the `CONTEXT_PATH` variable and building the full URL from it. This is how it was done before.

@bennychow please review and merge.