### PR TITLE
[CLEANUP] Fixed debugging with SuperDevMode, throwing exceptions

### DIFF
--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/utils/GWTUtils.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/utils/GWTUtils.java
@@ -1,0 +1,47 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.gwt.widgets.client.utils;
+
+import com.google.gwt.core.client.GWT;
+
+public class GWTUtils {
+  /**
+   * Gets a value that indicates whether the code is running in
+   * super dev mode.
+   * <p>
+   *   Adapted from https://github.com/gwtproject/gwt/issues/7631#issuecomment-110876132.
+   * </p>
+   */
+  public static boolean isSuperDevMode() {
+    return ((SuperDevModeIndicator) GWT.create( SuperDevModeIndicator.class ) )
+      .isSuperDevMode();
+  }
+
+  public static class SuperDevModeIndicator {
+    public boolean isSuperDevMode() {
+      return false;
+    }
+  }
+
+  public static class SuperDevModeIndicatorInSuperDevMode extends SuperDevModeIndicator {
+    @Override
+    public boolean isSuperDevMode() {
+      return true;
+    }
+  }
+}

--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/Widgets.gwt.xml
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/Widgets.gwt.xml
@@ -29,5 +29,11 @@
 
     <public path="public"/>
     <public path="client/filechooser/public"/>
+
+    <!-- Supports org.pentaho.gwt.widgets.client.utils.GWTUtils.isSuperDevMode() -->
+    <replace-with class="org.pentaho.gwt.widgets.client.utils.GWTUtils.SuperDevModeIndicatorInSuperDevMode">
+      <when-type-is class="org.pentaho.gwt.widgets.client.utils.GWTUtils.SuperDevModeIndicator"/>
+      <when-property-is name="superdevmode" value="on" />
+    </replace-with>
       
 </module>


### PR DESCRIPTION
@pentaho/wcag, please review.

This gets rid of an annoying assertion which comes up when using Super Dev Mode.
At this moment, the issue and one "dev environment" workaround are described in the wiki, https://hv-eng.atlassian.net/wiki/spaces/ENG/pages/30559307266/Failing+Assertions+-+GWT+-+SDM:
> Currently, assertions are failing in the User Console module, preventing the opening of the Perspectives and Logged-in User pull-down menus, in PUC’s header.

The fix here proposed is better:
1. The assertion is avoided altogether, and so the corresponding forced `debugger;` breakpoints are not hit.
2. The code does not affect the production build; in fact, due to code optimization, the new code is not even present.

The trick lies mostly in being able to detect when one is debugging in / compiling for Super Dev Mode. I found the solution here: https://github.com/gwtproject/gwt/issues/7631#issuecomment-110876132.