### PR TITLE
[BACKLOG-37092] Keyboard focus not automatically set on the first focusable element

### DIFF
--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/buttons/CustomButton.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/buttons/CustomButton.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara. All rights reserved.
  */
 
 package org.pentaho.gwt.widgets.client.buttons;
@@ -20,6 +20,7 @@ package org.pentaho.gwt.widgets.client.buttons;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.ui.ClickListener;
+import com.google.gwt.user.client.ui.HasEnabled;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.SimplePanel;
@@ -31,7 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @SuppressWarnings( "deprecation" )
-public class CustomButton extends Widget {
+public class CustomButton extends Widget implements HasEnabled {
 
   private String baseStyleName = "customButton"; //$NON-NLS-1$
   private Command command;

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/buttons/ImageButton.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/buttons/ImageButton.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara. All rights reserved.
  */
 
 package org.pentaho.gwt.widgets.client.buttons;
@@ -33,6 +33,7 @@ import com.google.gwt.event.dom.client.KeyUpEvent;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Focusable;
+import com.google.gwt.user.client.ui.HasEnabled;
 import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.impl.FocusImpl;
 import org.pentaho.gwt.widgets.client.utils.ElementUtils;
@@ -43,7 +44,7 @@ import org.pentaho.gwt.widgets.client.utils.ElementUtils;
  * @deprecated use {@link ThemeableImageButton}
  */
 @Deprecated
-public class ImageButton extends Image implements Focusable {
+public class ImageButton extends Image implements Focusable, HasEnabled {
 
   private boolean isEnabled = true;
 

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/buttons/RoundedButton.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/buttons/RoundedButton.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara. All rights reserved.
  */
 
 package org.pentaho.gwt.widgets.client.buttons;
@@ -27,6 +27,7 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.ui.ClickListener;
+import com.google.gwt.user.client.ui.HasEnabled;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.SimplePanel;
@@ -37,7 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @SuppressWarnings( "deprecation" )
-public class RoundedButton extends Widget implements HasClickHandlers {
+public class RoundedButton extends Widget implements HasClickHandlers, HasEnabled {
 
   private String text = ""; //$NON-NLS-1$
   private String baseStyleName = "roundedbutton"; //$NON-NLS-1$

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/buttons/ThemeableImageButton.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/buttons/ThemeableImageButton.java
@@ -36,13 +36,14 @@ import com.google.gwt.event.dom.client.MouseOverHandler;
 import com.google.gwt.event.dom.client.MouseUpEvent;
 import com.google.gwt.event.dom.client.MouseUpHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.ui.HasEnabled;
 import com.google.gwt.user.client.ui.Image;
 import org.pentaho.gwt.widgets.client.utils.ElementUtils;
 
 /**
  * Clickable image with enable/disable functionality built in. Makes use of css styles to provide the image and sizing.
  */
-public class ThemeableImageButton extends Image {
+public class ThemeableImageButton extends Image implements HasEnabled {
 
   private boolean isEnabled = true;
   private Set<String> enabledStyles = new HashSet<String>();

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/controls/DateTimePicker.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/controls/DateTimePicker.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara. All rights reserved.
  */
 
 package org.pentaho.gwt.widgets.client.controls;
@@ -21,6 +21,7 @@ import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.i18n.client.DateTimeFormat.PredefinedFormat;
 import com.google.gwt.user.client.ui.CellPanel;
 import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.HasEnabled;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
@@ -36,7 +37,7 @@ import java.util.Date;
  * 
  */
 
-public class DateTimePicker extends FlowPanel implements IChangeHandler {
+public class DateTimePicker extends FlowPanel implements IChangeHandler, HasEnabled {
   private DefaultFormat format = new DefaultFormat( DateTimeFormat.getFormat( PredefinedFormat.DATE_SHORT ) );
   protected DatePickerEx datePicker = new DatePickerEx( format );
   protected TimePicker timePicker = new TimePicker();

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/controls/TimePicker.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/controls/TimePicker.java
@@ -12,11 +12,12 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara. All rights reserved.
  */
 
 package org.pentaho.gwt.widgets.client.controls;
 
+import com.google.gwt.user.client.ui.HasEnabled;
 import org.pentaho.gwt.widgets.client.ui.ICallback;
 import org.pentaho.gwt.widgets.client.ui.IChangeHandler;
 import org.pentaho.gwt.widgets.client.utils.TimeUtil;
@@ -39,7 +40,7 @@ import com.google.gwt.user.client.ui.Widget;
  * 
  */
 @SuppressWarnings( "deprecation" )
-public class TimePicker extends HorizontalPanel implements IChangeHandler {
+public class TimePicker extends HorizontalPanel implements IChangeHandler, HasEnabled {
   protected ListBox hourLB = new ListBox();
   protected ListBox minuteLB = new ListBox();
   protected ListBox timeOfDayLB = new ListBox();
@@ -220,4 +221,7 @@ public class TimePicker extends HorizontalPanel implements IChangeHandler {
     timeOfDayLB.setEnabled( enabled );
   }
 
+  public boolean isEnabled() {
+    return hourLB.isEnabled();
+  }
 }

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/dialogs/DialogBox.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/dialogs/DialogBox.java
@@ -229,6 +229,7 @@ public class DialogBox extends com.google.gwt.user.client.ui.DialogBox implement
    * @see #getAutoFocusWidget()
    * @deprecated Use {@link #setFocusWidget(Focusable)} instead.
    */
+  @Deprecated
   public void setFocusWidget( FocusWidget widget ) {
     setFocusWidget( (Focusable) widget );
   }

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/dialogs/PromptDialogBox.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/dialogs/PromptDialogBox.java
@@ -23,12 +23,14 @@ import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.ClickListener;
 import com.google.gwt.user.client.ui.FlexTable;
 import com.google.gwt.user.client.ui.FocusWidget;
+import com.google.gwt.user.client.ui.Focusable;
 import com.google.gwt.user.client.ui.HasHorizontalAlignment;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.KeyboardListener;
 import com.google.gwt.user.client.ui.Widget;
 import org.pentaho.gwt.widgets.client.panel.HorizontalFlexPanel;
+import org.pentaho.gwt.widgets.client.utils.ElementUtils;
 
 @SuppressWarnings( "deprecation" )
 public class PromptDialogBox extends DialogBox {
@@ -37,6 +39,7 @@ public class PromptDialogBox extends DialogBox {
   IDialogValidatorCallback validatorCallback;
   Widget content;
   final FlexTable dialogContent = new FlexTable();
+
   protected Button okButton = null;
   protected Button notOkButton = null;
   protected Button cancelButton = null;
@@ -129,6 +132,30 @@ public class PromptDialogBox extends DialogBox {
     setContent( content );
   }
 
+  /**
+   * Gets the "OK" button.
+   * @return The "OK" button.
+   */
+  public Button getOkButton() {
+    return okButton;
+  }
+
+  /**
+   * Gets the "Not OK" button, if any.
+   * @return The "Not OK" button, if any; <code>null</code>, otherwise.
+   */
+  public Button getNotOkButton() {
+    return notOkButton;
+  }
+
+  /**
+   * Gets the "Cancel" button, if any.
+   * @return The "Cancel" button, if any; <code>null</code>, otherwise.
+   */
+  public Button getCancelButton() {
+    return cancelButton;
+  }
+
   public boolean onKeyDownPreview( char key, int modifiers ) {
     // Use the popup's key preview hooks to close the dialog when either
     // enter or escape is pressed.
@@ -171,6 +198,65 @@ public class PromptDialogBox extends DialogBox {
 
   public void setValidatorCallback( IDialogValidatorCallback validatorCallback ) {
     this.validatorCallback = validatorCallback;
+  }
+
+  /**
+   * Gets the default automatic focus widget by first delegating to
+   * {@link #getDefaultAutoFocusContentWidget()}, and, none being found,
+   * delegating to {@link #getDefaultAutoFocusButton()}.
+   *
+   * @return The default automatic focus widget.
+   */
+  @Override
+  protected Focusable getDefaultAutoFocusWidget() {
+    Focusable focusable = getDefaultAutoFocusContentWidget();
+    return focusable != null ? focusable : getDefaultAutoFocusButton();
+  }
+
+  /**
+   * Gets the default automatic focus content widget.
+   * <p>
+   *   The default implementation returns the first descendant of {@link #getContent()}
+   *   which is currently keyboard focusable, if any.
+   * </p>
+   * @return The default automatic focus content widget, if any; <code>null</code>, otherwise.
+   * @see ElementUtils#findFirstKeyboardFocusableDescendant(Widget)
+   */
+  protected Focusable getDefaultAutoFocusContentWidget() {
+    Widget content = getContent();
+    if ( content != null ) {
+      Focusable focusable = ElementUtils.findFirstKeyboardFocusableDescendant( content );
+      if ( focusable != null ) {
+        return focusable;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Gets the default automatic focus button.
+   * <p>
+   *   The default implementation returns the first keyboard focusable button
+   *   in order of less to greater dangerous/irreversible impact, i.e.,
+   *   from Cancel, Not Ok to Ok.
+   * </p>
+   * @return The default automatic focus button, if any; <code>null</code>, otherwise.
+   */
+  protected Button getDefaultAutoFocusButton() {
+    if ( ElementUtils.isKeyboardFocusableLocal( getCancelButton() ) ) {
+      return getCancelButton();
+    }
+
+    if ( ElementUtils.isKeyboardFocusableLocal( getNotOkButton() )  ) {
+      return getNotOkButton();
+    }
+
+    if ( ElementUtils.isKeyboardFocusableLocal( getOkButton() )  ) {
+      return getOkButton();
+    }
+
+    return null;
   }
 
   protected void onOk() {

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/dialogs/PromptDialogBox.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/dialogs/PromptDialogBox.java
@@ -223,9 +223,8 @@ public class PromptDialogBox extends DialogBox {
    * @see ElementUtils#findFirstKeyboardFocusableDescendant(Widget)
    */
   protected Focusable getDefaultAutoFocusContentWidget() {
-    Widget content = getContent();
-    if ( content != null ) {
-      Focusable focusable = ElementUtils.findFirstKeyboardFocusableDescendant( content );
+    if ( getContent() != null ) {
+      Focusable focusable = ElementUtils.findFirstKeyboardFocusableDescendant( getContent() );
       if ( focusable != null ) {
         return focusable;
       }

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/listbox/CustomListBox.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/listbox/CustomListBox.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara. All rights reserved.
  */
 
 package org.pentaho.gwt.widgets.client.listbox;
@@ -20,6 +20,7 @@ package org.pentaho.gwt.widgets.client.listbox;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.gwt.user.client.ui.HasEnabled;
 import org.pentaho.gwt.widgets.client.utils.ElementUtils;
 import org.pentaho.gwt.widgets.client.utils.Rectangle;
 import org.pentaho.gwt.widgets.client.utils.string.StringUtils;
@@ -80,7 +81,7 @@ import com.google.gwt.user.client.ui.Widget;
  */
 @SuppressWarnings( "deprecation" )
 public class CustomListBox extends HorizontalPanel implements ChangeListener, PopupListener, MouseListener,
-    FocusListener, KeyboardListener, ListItemListener {
+    FocusListener, KeyboardListener, ListItemListener, HasEnabled {
   protected List<ListItem> items = new ArrayList<ListItem>();
   protected int selectedIndex = -1;
   protected DropDownArrow arrow = new DropDownArrow();

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/toolbar/Toolbar.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/toolbar/Toolbar.java
@@ -12,12 +12,13 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara. All rights reserved.
  */
 
 package org.pentaho.gwt.widgets.client.toolbar;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.ui.HasEnabled;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Label;
@@ -35,7 +36,7 @@ import java.util.List;
  * 
  * @author nbaker
  */
-public class Toolbar extends HorizontalPanel implements ToolbarPopupListener, ToolbarPopupSource {
+public class Toolbar extends HorizontalPanel implements ToolbarPopupListener, ToolbarPopupSource, HasEnabled {
 
   public static final int SEPARATOR = 1;
 
@@ -51,6 +52,8 @@ public class Toolbar extends HorizontalPanel implements ToolbarPopupListener, To
   protected List<ToolbarGroup> groups = new ArrayList<ToolbarGroup>();
 
   protected List<ToolbarPopupListener> popupListeners = new ArrayList<ToolbarPopupListener>();
+
+  private boolean enabled = true;
 
   public Toolbar() {
     this.setStylePrimaryName( "toolbar" ); //$NON-NLS-1$
@@ -181,6 +184,7 @@ public class Toolbar extends HorizontalPanel implements ToolbarPopupListener, To
    *          boolean flag
    */
   public void setEnabled( boolean enabled ) {
+    this.enabled = enabled;
     try {
       for ( ToolbarButton button : this.buttons ) {
         button.setEnabled( enabled );
@@ -196,6 +200,10 @@ public class Toolbar extends HorizontalPanel implements ToolbarPopupListener, To
       System.out.println( "Error with Disable: " + e ); //$NON-NLS-1$
       e.printStackTrace( System.out );
     }
+  }
+
+  public boolean isEnabled() {
+    return enabled;
   }
 
   public void addPopupPanelListener( ToolbarPopupListener listener ) {

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/utils/FlexTableDocumentOrderIterator.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/utils/FlexTableDocumentOrderIterator.java
@@ -1,0 +1,117 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.gwt.widgets.client.utils;
+
+import com.google.gwt.user.client.ui.FlexTable;
+import com.google.gwt.user.client.ui.Widget;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public class FlexTableDocumentOrderIterator implements Iterator<Widget> {
+
+  private static class Cell {
+    public final int row;
+    public final int column;
+    public final Widget widget;
+
+    public Cell( int row, int column, Widget widget ) {
+      assert row >= 0;
+      assert column >= 0;
+      assert widget != null;
+
+      this.row = row;
+      this.column = column;
+      this.widget = widget;
+    }
+  }
+
+  private final FlexTable table;
+  private Cell lastCell;
+  private Cell nextCell;
+
+  public FlexTableDocumentOrderIterator( FlexTable table ) {
+    if ( table == null ) {
+      throw new IllegalArgumentException( "table cannot be null" );
+    }
+
+    this.table = table;
+    this.nextCell = findNextCell( -1, -1 );
+  }
+
+  private Cell findNextCell( int row, int column ) {
+    while ( true ) {
+      // When initializing, row is -1.
+      if ( row >= 0 ) {
+        // Exhaust current row's cells.
+        Cell nextCell = findNextCellOfRow( row, column );
+        if ( nextCell != null ) {
+          return nextCell;
+        }
+      }
+
+      // Advance to next row.
+      if ( ++row >= table.getRowCount() ) {
+        // There is no next row.
+        return null;
+      }
+
+      // Reset column.
+      column = -1;
+    }
+  }
+
+  private Cell findNextCellOfRow( final int row, int col ) {
+    int colCount = table.getCellCount( row );
+    while ( ++col < colCount ) {
+      Widget widget = table.getWidget( row, col );
+      if ( widget != null ) {
+        return new Cell( row, col, widget );
+      }
+    }
+
+    return null;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return nextCell != null;
+  }
+
+  @Override
+  public Widget next() {
+    if ( nextCell == null ) {
+      throw new NoSuchElementException();
+    }
+
+    lastCell = nextCell;
+    nextCell = findNextCell( nextCell.row, nextCell.column );
+
+    return lastCell.widget;
+  }
+
+  @Override
+  public void remove() {
+    if ( lastCell == null ) {
+      throw new IllegalStateException();
+    }
+
+    table.remove( lastCell.widget );
+    lastCell = null;
+  }
+}

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/utils/FlexTableDocumentOrderIterator.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/utils/FlexTableDocumentOrderIterator.java
@@ -59,9 +59,9 @@ public class FlexTableDocumentOrderIterator implements Iterator<Widget> {
       // When initializing, row is -1.
       if ( row >= 0 ) {
         // Exhaust current row's cells.
-        Cell nextCell = findNextCellOfRow( row, column );
-        if ( nextCell != null ) {
-          return nextCell;
+        Cell nextCellOfRow = findNextCellOfRow( row, column );
+        if ( nextCellOfRow != null ) {
+          return nextCellOfRow;
         }
       }
 

--- a/widgets/src/test/java/org/pentaho/gwt/widgets/client/dialogs/DialogBoxTest.java
+++ b/widgets/src/test/java/org/pentaho/gwt/widgets/client/dialogs/DialogBoxTest.java
@@ -12,24 +12,68 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+* Copyright (c) 2002-2023 Hitachi Vantara. All rights reserved.
 */
 
 package org.pentaho.gwt.widgets.client.dialogs;
 
 import com.google.gwt.user.client.ui.FocusWidget;
+import com.google.gwt.user.client.ui.Focusable;
+import com.google.gwt.user.client.ui.HasEnabled;
+import com.google.gwt.user.client.ui.HasWidgets;
 import com.google.gwt.user.client.ui.KeyboardListener;
+import com.google.gwt.user.client.ui.Widget;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.*;
 
 @RunWith( GwtMockitoTestRunner.class )
 @SuppressWarnings( "deprecation" )
 public class DialogBoxTest {
+
+  // region Helpers
+  private static Widget mockContainerWidget() {
+    Widget widgetMock = mock(
+      Widget.class,
+      withSettings().extraInterfaces( HasWidgets.class ) );
+
+    Iterator<Widget> iteratorMock = (Iterator<Widget>) mock( Iterator.class );
+    when( ( (HasWidgets) widgetMock ).iterator() ).thenReturn( iteratorMock );
+    when( widgetMock.isVisible() ).thenReturn( true );
+
+    return widgetMock;
+  }
+
+  private static Widget mockFocusableWidget() {
+    Widget widgetMock = mock(
+      Widget.class,
+      withSettings().extraInterfaces( Focusable.class, HasEnabled.class ) );
+
+    when( ( (Focusable) widgetMock ).getTabIndex() ).thenReturn( 0 );
+    when( ( (HasEnabled) widgetMock ).isEnabled() ).thenReturn( true );
+    when( widgetMock.isVisible() ).thenReturn( true );
+
+    return widgetMock;
+  }
+
+  private static Widget mockFocusableChildInContainer( HasWidgets widgetMock ) {
+    Iterator<Widget> iteratorMock = widgetMock.iterator();
+    when( iteratorMock.hasNext() ).thenReturn( true );
+
+    Widget childMock = mockFocusableWidget();
+    when( iteratorMock.next() ).thenReturn( mock( Widget.class ), childMock );
+    return childMock;
+  }
+  // endregion
+
   @Test
-  public void testOnKeyDownPreview() throws Exception {
+  public void testOnKeyDownPreview() {
     DialogBox box = mock( DialogBox.class );
     doCallRealMethod().when( box ).onKeyDownPreview( anyChar(), anyInt() );
 
@@ -37,15 +81,124 @@ public class DialogBoxTest {
     verify( box, times( 1 ) ).hide();
   }
 
+  // region setFocusWidget
   @Test
-  public void testSetFocusWidget() throws Exception {
-    DialogBox box = mock( DialogBox.class );
-    doCallRealMethod().when( box ).setFocusWidget( any( FocusWidget.class ) );
-    doCallRealMethod().when( box ).getAutoFocusWidget();
-    doCallRealMethod().when( box ).doAutoFocus();
+  public void testSetFocusWidgetRespectsTheSpecifiedValue() {
+    DialogBox box = new DialogBox( false, false );
+
+    FocusWidget focusWidget = mock( FocusWidget.class );
+
+    box.setFocusWidget( focusWidget );
+
+    assertEquals( focusWidget, box.getFocusWidget() );
+  }
+
+  @Test
+  public void testSetFocusWidgetCallsDoAutoFocus() {
+    DialogBox box = spy( new DialogBox( false, false ) );
+
+    FocusWidget focusWidget = mock( FocusWidget.class );
+
+    box.setFocusWidget( focusWidget );
+
+    verify( box, times( 1 ) ).doAutoFocus();
+  }
+  // endregion
+
+  // region doAutoFocus()
+  @Test
+  public void testDoAutoFocusSetsFocusOnAutoFocusWidgetWhenDialogIsShowingAndVisible() {
+    DialogBox box = spy( new DialogBox( false, false ) );
+    doReturn( true ).when( box ).isShowing();
+    doReturn( true ).when( box ).isVisible();
+
+    Focusable focusWidget = mock( Focusable.class );
+    doReturn( focusWidget ).when( box ).getAutoFocusWidget();
+
+    box.doAutoFocus();
+
+    verify( focusWidget ).setFocus( true );
+  }
+
+  @Test
+  public void testDoAutoFocusDoesNotSetFocusOnWidgetWhenDialogNotShowing() {
+    DialogBox box = spy( new DialogBox( false, false ) );
+    doReturn( false ).when( box ).isShowing();
+    doReturn( true ).when( box ).isVisible();
 
     final FocusWidget focusWidget = mock( FocusWidget.class );
     box.setFocusWidget( focusWidget );
-    verify( focusWidget ).setFocus( true );
+
+    verify( focusWidget, never() ).setFocus( true );
   }
+
+  @Test
+  public void testDoAutoFocusDoesNotSetFocusOnWidgetWhenDialogShowingButNotVisible() {
+    DialogBox box = spy( new DialogBox( false, false ) );
+    doReturn( true ).when( box ).isShowing();
+    doReturn( false ).when( box ).isVisible();
+
+    final FocusWidget focusWidget = mock( FocusWidget.class );
+    box.setFocusWidget( focusWidget );
+
+    verify( focusWidget, never() ).setFocus( true );
+  }
+
+  @Test
+  public void testDoAutoFocusDoesNothingWhenThereIsNoAutoFocusWidget() {
+    DialogBox box = spy( new DialogBox( false, false ) );
+    doReturn( true ).when( box ).isShowing();
+    doReturn( true ).when( box ).isVisible();
+    doReturn( null ).when( box ).getAutoFocusWidget();
+
+    box.doAutoFocus();
+  }
+  // endregion
+
+  // region getAutoFocusWidget()
+  @Test
+  public void testGetAutoFocusWidgetReturnsFocusWidgetWhenSet() {
+    DialogBox box = spy( new DialogBox( false, false ) );
+
+    final FocusWidget focusWidget = mock( FocusWidget.class );
+    box.setFocusWidget( focusWidget );
+
+    assertEquals( focusWidget, box.getAutoFocusWidget() );
+  }
+
+  @Test
+  public void testGetAutoFocusWidgetReturnsGetDefaultAutoFocusWidgetWhenFocusWidgetNotSet() {
+    DialogBox box = spy( new DialogBox( false, false ) );
+    doReturn( null ).when( box ).getWidget();
+
+    final Focusable focusWidget = mock( Focusable.class );
+    doReturn( focusWidget ).when( box ).getDefaultAutoFocusWidget();
+
+    assertEquals( focusWidget, box.getAutoFocusWidget() );
+  }
+  // endregion
+
+  // region getDefaultAutoFocusWidget()
+  @Test
+  public void testGetDefaultAutoFocusWidgetReturnsNullWhenNotGetWidget() {
+    DialogBox box = spy( new DialogBox( false, false ) );
+
+    doReturn( null ).when( box ).getWidget();
+
+    assertNull( box.getDefaultAutoFocusWidget() );
+  }
+
+  @Test
+  public void testGetDefaultAutoFocusWidgetReturnsFirstFocusableWidget() {
+    DialogBox box = spy( new DialogBox( false, false ) );
+
+    Widget widgetMock = mockContainerWidget();
+    Widget childMock = mockFocusableChildInContainer( (HasWidgets) widgetMock );
+
+    doReturn( widgetMock ).when( box ).getWidget();
+
+    assertEquals( childMock, box.getDefaultAutoFocusWidget() );
+  }
+
+  // endregion
 }

--- a/widgets/src/test/java/org/pentaho/gwt/widgets/client/dialogs/DialogBoxTest.java
+++ b/widgets/src/test/java/org/pentaho/gwt/widgets/client/dialogs/DialogBoxTest.java
@@ -152,6 +152,8 @@ public class DialogBoxTest {
     doReturn( null ).when( box ).getAutoFocusWidget();
 
     box.doAutoFocus();
+
+    // Nothing can be asserted. Provides assurance it does not throw and coverage.
   }
   // endregion
 

--- a/widgets/src/test/java/org/pentaho/gwt/widgets/client/utils/ElementUtilsTest.java
+++ b/widgets/src/test/java/org/pentaho/gwt/widgets/client/utils/ElementUtilsTest.java
@@ -1,0 +1,253 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.gwt.widgets.client.utils;
+
+import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.ui.FlexTable;
+import com.google.gwt.user.client.ui.Focusable;
+import com.google.gwt.user.client.ui.HasEnabled;
+import com.google.gwt.user.client.ui.HasWidgets;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+@RunWith( GwtMockitoTestRunner.class )
+public class ElementUtilsTest {
+
+  // region Helpers
+  public static Widget mockFocusableWidget() {
+    Widget widgetMock = mock(
+      Widget.class,
+      withSettings().extraInterfaces( Focusable.class, HasEnabled.class ) );
+
+    when( ( (Focusable) widgetMock ).getTabIndex() ).thenReturn( 0 );
+    when( ( (HasEnabled) widgetMock ).isEnabled() ).thenReturn( true );
+    when( widgetMock.isVisible() ).thenReturn( true );
+
+    return widgetMock;
+  }
+
+  public static Widget mockContainerWidget() {
+    Widget widgetMock = mock(
+      Widget.class,
+      withSettings().extraInterfaces( HasWidgets.class ) );
+
+    Iterator<Widget> iteratorMock = (Iterator<Widget>) mock( Iterator.class );
+    when( ( (HasWidgets) widgetMock ).iterator() ).thenReturn( iteratorMock );
+    when( widgetMock.isVisible() ).thenReturn( true );
+
+    return widgetMock;
+  }
+
+  private static Widget mockFocusableChildInContainer( HasWidgets widgetMock ) {
+    Iterator<Widget> iteratorMock = widgetMock.iterator();
+    when( iteratorMock.hasNext() ).thenReturn( true );
+
+    Widget childMock = mockFocusableWidget();
+    when( iteratorMock.next() ).thenReturn( mock( Widget.class ), childMock );
+    return childMock;
+  }
+  // endregion
+
+  // region isEnabled
+  @Test
+  public void testIsEnabledWhenWidgetImplementsHasEnabledDelegatesToIt() {
+    Widget widgetMock = mock( Widget.class, withSettings().extraInterfaces( HasEnabled.class ) );
+
+    // When disabled.
+    when( ( (HasEnabled) widgetMock ).isEnabled() ).thenReturn( false );
+
+    assertFalse( ElementUtils.isEnabled( widgetMock ) );
+
+    verify( (HasEnabled) widgetMock, times( 1 ) ).isEnabled();
+
+    // When enabled.
+    when( ( (HasEnabled) widgetMock ).isEnabled() ).thenReturn( true );
+
+    assertTrue( ElementUtils.isEnabled( widgetMock ) );
+
+    verify( (HasEnabled) widgetMock, times( 2 ) ).isEnabled();
+  }
+
+  @Test
+  public void testIsEnabledWhenWidgetDoesNotImplementHasEnabledChecksElementProperty() {
+    Widget widgetMock = mock( Widget.class );
+
+    Element elementMock = mock( Element.class );
+    when( widgetMock.getElement() ).thenReturn( elementMock );
+
+    // When disabled.
+    when( elementMock.getPropertyBoolean( "disabled" ) ).thenReturn( true );
+
+    assertFalse( ElementUtils.isEnabled( widgetMock ) );
+
+    verify( elementMock, times( 1 ) ).getPropertyBoolean( "disabled" );
+
+    // When enabled.
+    when( elementMock.getPropertyBoolean( "disabled" ) ).thenReturn( false );
+
+    assertTrue( ElementUtils.isEnabled( widgetMock ) );
+
+    verify( elementMock, times( 2 ) ).getPropertyBoolean( "disabled" );
+  }
+  // endregion
+
+  // region isKeyboardFocusableLocal
+  @Test
+  public void testIsKeyboardFocusableLocalReturnsTrueWhenMeetsAllCriteria() {
+    Widget widgetMock = mockFocusableWidget();
+
+    assertTrue( ElementUtils.isKeyboardFocusableLocal( widgetMock ) );
+  }
+
+  @Test
+  public void testIsKeyboardFocusableLocalReturnsTrueWhenTabIndexIsPositive() {
+    Widget widgetMock = mockFocusableWidget();
+
+    when( ( (Focusable) widgetMock ).getTabIndex() ).thenReturn( 1 );
+
+    assertTrue( ElementUtils.isKeyboardFocusableLocal( widgetMock ) );
+  }
+
+  @Test
+  public void testIsKeyboardFocusableLocalReturnsFalseWhenWidgetIsNotInstanceOfFocusable() {
+    Widget widgetMock = mock(
+      Widget.class,
+      withSettings().extraInterfaces( HasEnabled.class ) );
+
+    when( ( (HasEnabled) widgetMock ).isEnabled() ).thenReturn( true );
+    when( widgetMock.isVisible() ).thenReturn( true );
+
+    assertFalse( ElementUtils.isKeyboardFocusableLocal( widgetMock ) );
+  }
+
+  @Test
+  public void testIsKeyboardFocusableLocalReturnsFalseWhenWidgetHasNegativeTabIndex() {
+    Widget widgetMock = mockFocusableWidget();
+    when( ( (Focusable) widgetMock ).getTabIndex() ).thenReturn( -1 );
+
+    assertFalse( ElementUtils.isKeyboardFocusableLocal( widgetMock ) );
+  }
+
+  @Test
+  public void testIsKeyboardFocusableLocalReturnsFalseWhenWidgetIsNotEnabled() {
+    Widget widgetMock = mockFocusableWidget();
+    when( ( (HasEnabled) widgetMock ).isEnabled() ).thenReturn( false );
+
+    assertFalse( ElementUtils.isKeyboardFocusableLocal( widgetMock ) );
+  }
+
+  @Test
+  public void testIsKeyboardFocusableLocalReturnsFalseWhenWidgetIsNotVisible() {
+    Widget widgetMock = mockFocusableWidget();
+    when( widgetMock.isVisible() ).thenReturn( false );
+
+    assertFalse( ElementUtils.isKeyboardFocusableLocal( widgetMock ) );
+  }
+  // endregion
+
+  // region findFirstKeyboardFocusableDescendant
+  @Test
+  public void testFindFirstKeyboardFocusableDescendantReturnsSelfWhenVisibleAndKeyboardFocusable() {
+    Widget widgetMock = mockFocusableWidget();
+
+    assertEquals( widgetMock, ElementUtils.findFirstKeyboardFocusableDescendant( widgetMock ) );
+  }
+
+  @Test
+  public void testFindFirstKeyboardFocusableDescendantReturnsNullWhenNotVisible() {
+    Widget widgetMock = mockFocusableWidget();
+    when( widgetMock.isVisible() ).thenReturn( false );
+
+    assertNull( ElementUtils.findFirstKeyboardFocusableDescendant( widgetMock ) );
+  }
+
+  @Test
+  public void testFindFirstKeyboardFocusableDescendantReturnsNullWhenVisibleAndNotFocusableAndNotHasWidgets() {
+    Widget widgetMock = mock( Widget.class );
+    when( widgetMock.isVisible() ).thenReturn( true );
+
+    assertNull( ElementUtils.findFirstKeyboardFocusableDescendant( widgetMock ) );
+  }
+
+  @Test
+  public void testFindFirstKeyboardFocusableDescendantReturnsNullWhenVisibleAndNotFocusableAndHasZeroWidgets() {
+    Widget widgetMock = mockContainerWidget();
+
+    assertEquals( null, ElementUtils.findFirstKeyboardFocusableDescendant( widgetMock ) );
+  }
+
+  @Test
+  public void testFindFirstKeyboardFocusableDescendantReturnsFocusableChild() {
+    Widget widgetMock = mockContainerWidget();
+    Widget childMock = mockFocusableChildInContainer( (HasWidgets) widgetMock );
+
+    assertEquals( childMock, ElementUtils.findFirstKeyboardFocusableDescendant( widgetMock ) );
+  }
+
+  @Test
+  public void testFindFirstKeyboardFocusableDescendantReturnsNullWhenNoFocusableChildren() {
+    Widget widgetMock = mockContainerWidget();
+    Iterator<Widget> iteratorMock = ( (HasWidgets) widgetMock ).iterator();
+    when( iteratorMock.hasNext() ).thenReturn( true, true, false );
+
+    when( iteratorMock.next() ).thenReturn( mock( Widget.class ), mock( Widget.class ) );
+
+    assertNull( ElementUtils.findFirstKeyboardFocusableDescendant( widgetMock ) );
+  }
+
+  @Test
+  public void testFindFirstKeyboardFocusableDescendantWhenFlexTableReturnsFirstDocumentOrderFocusableChild() {
+    FlexTable tableMock = mock( FlexTable.class );
+    when( tableMock.isVisible() ).thenReturn( true );
+
+    when( tableMock.getRowCount() ).thenReturn( 4 );
+    when( tableMock.getCellCount( anyInt() ) ).thenReturn( 2 );
+
+    Widget child1Mock = mock( Widget.class );
+    Widget child2Mock = mock( Widget.class );
+    Widget child3Mock = mockFocusableWidget();
+    Widget child4Mock = mock( Widget.class );
+    Widget child5Mock = mockFocusableWidget();
+
+    when( tableMock.getWidget( 1, 1 ) ).thenReturn( child1Mock );
+    when( tableMock.getWidget( 1, 2 ) ).thenReturn( child2Mock );
+    when( tableMock.getWidget( 2, 1 ) ).thenReturn( child3Mock );
+    when( tableMock.getWidget( 2, 2 ) ).thenReturn( child4Mock );
+    when( tableMock.getWidget( 3, 0 ) ).thenReturn( child5Mock );
+
+    assertEquals( child3Mock, ElementUtils.findFirstKeyboardFocusableDescendant( tableMock ) );
+  }
+  // endregion
+}


### PR DESCRIPTION
@pentaho/wcag, please review.

**Summary**
- Fixed traversing through `FlexTable`'s not being done in document order, affecting focus order determination, when used as a Layout table.
- Fixed components which support isEnabled/setEnabled pattern but were not marked as `HasEnabled`, which affects keyboard focusability determination
- Fixed `PromptDialogBox` using the document order for both the body and the buttons section. The body area still uses document order, while the buttons section now uses a "less dangerous action first" heuristic for ordering.
- Added missing documentation to existing focus related methods. Also some renames where appropriate.