### PR TITLE
[BACKLOG-36883] xul tag: <toolbarbutton>:: Functional images don't provide text alternative

### DIFF
--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/toolbar/ToolbarButton.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/toolbar/ToolbarButton.java
@@ -338,6 +338,14 @@ public class ToolbarButton {
   }
 
   /**
+   * Returns the alternative image text.
+   * @return null if image is null
+   */
+  public String getImageAltText() {
+    return ( this.image != null ) ? this.image.getAltText() : null;
+  }
+
+  /**
    * Returns the image displayed on this button.
    * 
    * @return GWT Image
@@ -359,6 +367,16 @@ public class ToolbarButton {
     button.add( curImage, DockPanel.CENTER );
     button.setCellHorizontalAlignment( curImage, DockPanel.ALIGN_CENTER );
     button.setCellVerticalAlignment( curImage, DockPanel.ALIGN_MIDDLE );
+  }
+
+  /**
+   * Set image alternative text.
+   * @param altText alternative text
+   */
+  public void setImageAltText( String altText ) {
+    if ( this.image != null ) {
+      this.image.setAltText( altText );
+    }
   }
 
   /**

--- a/widgets/src/test/java/org/pentaho/gwt/widgets/client/toolbar/ToolbarButtonTest.java
+++ b/widgets/src/test/java/org/pentaho/gwt/widgets/client/toolbar/ToolbarButtonTest.java
@@ -34,9 +34,21 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pentaho.gwt.widgets.client.text.ToolTip;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.contains;
 import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith( GwtMockitoTestRunner.class )
 public class ToolbarButtonTest {
@@ -161,6 +173,33 @@ public class ToolbarButtonTest {
   }
 
   @Test
+  public void testSetImageAltText() throws Exception {
+    // SETUP
+    String altText = "Test Some Alternative Text";
+    Image mockImage = mock( Image.class );
+    ToolbarButton testInstance = new ToolbarButton( mockImage );
+
+    // EXECUTE
+    testInstance.setImageAltText( altText );
+
+    // VERIFY
+    verify( mockImage ).setAltText( altText );
+  }
+
+  @Test
+  public void testSetImageAltText_nullImage() throws Exception {
+    // SETUP
+    Image mockImage = mock( Image.class );
+    ToolbarButton testInstance = new ToolbarButton( null );
+
+    // EXECUTE
+    testInstance.setImageAltText( "testSomeText" );
+
+    // VERIFY
+    verify( mockImage, never() ).setAltText(  anyString() );
+  }
+
+  @Test
   public void testSetDisabledImage() throws Exception {
     doCallRealMethod().when( button ).setDisabledImage( any( Image.class ) );
 
@@ -244,5 +283,25 @@ public class ToolbarButtonTest {
     verify( disabledImage ).addMouseOutHandler( any( MouseOutHandler.class ) );
     verify( disabledImage ).addMouseDownHandler( any( MouseDownHandler.class ) );
     verify( disabledImage ).addMouseUpHandler( any( MouseUpHandler.class ) );
+  }
+
+  @Test
+  public void testGetImageAltText() throws Exception {
+
+    // SETUP 1 : null image
+    ToolbarButton testInstance1 = new ToolbarButton( null );
+
+    // EXECUTE & VERIFY
+    assertNull( testInstance1.getImageAltText() );
+
+    // SETUP 2: non null image
+    String altText = "Test Some Alternative Text";
+    Image mockImage = mock( Image.class );
+    ToolbarButton testInstance2 = new ToolbarButton( mockImage );
+    when( mockImage.getAltText() ).thenReturn( altText );
+
+    // EXECUTE & VERIFY
+    assertEquals( altText, testInstance2.getImageAltText() );
+
   }
 }


### PR DESCRIPTION
- add ToolbarButton#setImageAltText and ToolbarButton#getImageAltText