### PR TITLE
[BACKLOG-37004] Fixed dialogs' title ellipsis not showing

### DIFF
--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/ruby/globalRuby.css
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/ruby/globalRuby.css
@@ -1432,8 +1432,6 @@ button#schedule-dialog-select-button {
 
 .pentaho-dialog.responsive .Caption {
   flex: none;
-  display: flex;
-  flex-direction: row;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1537,8 +1535,6 @@ button#schedule-dialog-select-button {
 }
 /* endregion GWT DialogBox, PromptDialogBox RESPONSIVE */
 
-/**/
-
 /* region BootstrapJS Dialog Responsive - Start */
 .bootstrap .modal.pentaho-dialog.responsive .body,
 .bootstrap .modal.pentaho-dialog.responsive .footer{
@@ -1548,6 +1544,12 @@ button#schedule-dialog-select-button {
 
 .bootstrap .modal.pentaho-dialog.responsive {
   padding: 0;
+}
+
+.bootstrap .modal.pentaho-dialog.responsive .Caption .header-content {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .bootstrap .modal.pentaho-dialog.responsive .button-panel {


### PR DESCRIPTION
- For GWT, XUL/GWT and BootstrapJS dialogs

@pentaho/wcag, please, review.