### PR TITLE
[BACKLOG-37152] WCAG - Data Source Wizard 'Source Type' dropdown arrow is outside of the box

### DIFF
--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/ruby/globalRuby.css
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/ruby/globalRuby.css
@@ -5299,6 +5299,14 @@ td.tab-spacer-wrapper {
   width: 0 !important;
 }
 
+:is(.custom-list, .custom-list-disabled) .custom-list-drop-grid > tbody > tr {
+  display:flex;
+}
+
+:is(.custom-list, .custom-list-disabled) .custom-list-drop-grid > tbody > tr > td:first-child {
+  flex:auto;
+}
+
 :is(.custom-list, .custom-list-disabled) .custom-list-drop-grid > tbody > tr > td:last-child {
   flex: none;
   width: auto !important;


### PR DESCRIPTION
@pentaho/wcag , Please review.