### PR TITLE
[BACKLOG-36953] Cleanup icons and buttons styles to integrate with new icon-zoomable style

### DIFF
--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/ruby/globalRuby.css
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/ruby/globalRuby.css
@@ -2902,371 +2902,291 @@ body.IE>table {
   margin: 0 10px;
 }
 
-.pentaho-savebutton-small {
-  width: 22px;
-  height: 22px;
-  background: url('images/save_22.png') no-repeat center;
-  cursor: pointer;
-}
-
-.pentaho-saveasbutton-small {
-  width: 22px;
-  height: 22px;
-  background: url('images/saveas_22.png') no-repeat center;
-  cursor: pointer;
-}
-
-.pentaho-openbutton-small {
-  width: 26px;
-  height: 22px;
-  background: url('images/open_22.png') no-repeat center;
-  cursor: pointer;
-}
-
-.pentaho-newbutton-small {
-  width: 22px;
-  height: 22px;
-  background: url('images/new_22.png') no-repeat center;
-  cursor: pointer;
-}
-
 .back-icon {
-  width: 22px;
-  height: 22px;
-  background: url('images/back_22.png') no-repeat center;
+  height: calc(1px * var(--icon-height));
+  width: calc(1px * var(--icon-width));
+
+  background-image: url('images/back_22.png');
+  background-repeat: no-repeat;
+  background-position: center;
+
   cursor: pointer;
 }
 
-#mqlFilterGroupbox #mqlFilterEditButton img.image-button-pressed,
-#mqlFilterGroupbox #mqlFilterEditButton img.image-button-over,
-#sqlFilterGroupbox #editQueryButton img.image-button-pressed,
-#sqlFilterGroupbox #editQueryButton img.image-button-over,
-#mqlFilterGroupbox #mqlFilterEditButton img.image-button,
-#sqlFilterGroupbox #editQueryButton img.image-button,
-.pentaho-editbutton {
-  width: 22px;
-  height: 22px;
+:is(
+  #mqlFilterGroupbox #mqlFilterEditButton,
+  #sqlFilterGroupbox #editQueryButton
+) img:is(.image-button-pressed, .image-button-over, .image-button) {
+  height: calc(1px * var(--icon-height));
+  width: calc(1px * var(--icon-width));
+
   background: url('images/edit_22.png') no-repeat center;
   cursor: pointer;
 }
 
-#mqlFilterGroupbox #mqlFilterEditButton img.disabled-image-button-pressed,
-#mqlFilterGroupbox #mqlFilterEditButton img.disabled-image-button-over,
-#sqlFilterGroupbox #editQueryButton img.disabled-image-button-pressed,
-#sqlFilterGroupbox #editQueryButton img.disabled-image-button-over,
-#mqlFilterGroupbox #mqlFilterEditButton img.disabled-image-button,
-#sqlFilterGroupbox #editQueryButton img.disabled-image-button,
-.pentaho-editbutton.pentaho-imagebutton-disabled {
-  width: 22px;
-  height: 22px;
+:is(
+  #mqlFilterGroupbox #mqlFilterEditButton,
+  #sqlFilterGroupbox #editQueryButton
+) img:is(.disabled-image-button-pressed, .disabled-image-button-over, .disabled-image-button) {
+  height: calc(1px * var(--icon-height));
+  width: calc(1px * var(--icon-width));
+
   background: url('images/edit_22_disabled.png') no-repeat center;
   cursor: default;
 }
 
-.pentaho-addbutton, .pentaho-addbutton.icon-zoomable {
-  --icon-height: var(--icon-height-root);
-  --icon-width: var(--icon-width-root);
-}
-.pentaho-addbutton {
+.fieldList .fieldListTop .clearSearchField {
   height: calc(1px * var(--icon-height));
   width: calc(1px * var(--icon-width));
 
-  background-image: url('images/add.png');
+  background: url('images/remove.png') no-repeat center;
+  cursor: pointer;
+  top: 0;
+}
+
+/* region Pentaho Buttons */
+
+/* region Pentaho Buttons default size */
+.pentaho-addbutton, .pentaho-addcombobutton, .pentaho-closebutton-big,
+.pentaho-datasourcebutton, .pentaho-deletebutton, .pentaho-editbutton,
+.pentaho-exportbutton, .pentaho-newbutton-small, .pentaho-openbutton-small,
+.pentaho-redobutton, .pentaho-saveasbutton-small, .pentaho-savebutton-small,
+.pentaho-undobutton {
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
+
+  height: calc(1px * var(--icon-height));
+  width: calc(1px * var(--icon-width));
+
   background-repeat: no-repeat;
   background-position: center;
   cursor: pointer;
-}
-
-.pentaho-addbutton.pentaho-imagebutton-disabled {
-  background-image: url('images/add_disabled.png');
-  background-repeat: no-repeat;
-  background-position: center;
-  cursor: default;
 }
 
 .pentaho-addcombobutton {
-  width: 22px;
-  height: 22px;
-  background: url('../images/add_combo.png') no-repeat center;
-  cursor: pointer;
+  background-image: url('images/add_combo.png');
 }
-
 .pentaho-addcombobutton.pentaho-imagebutton-disabled {
-  width: 22px;
-  height: 22px;
-  background: url('../images/add_combo_disabled.png') no-repeat center;
-  cursor: default;
+  background-image: url('../images/add_combo_disabled.png');
 }
 
-.pentaho-exportbutton {
-  width: 22px;
-  height: 22px;
-  background: url('../images/export.png') no-repeat center;
-  cursor: pointer;
+.pentaho-addbutton {
+  background-image: url('images/add.png');
 }
-
-.pentaho-exportbutton.pentaho-imagebutton-disabled {
-  width: 22px;
-  height: 22px;
-  background: url('../images/export_disabled.png') no-repeat center;
-  cursor: default;
+.pentaho-addbutton.icon-zoomable {
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
 }
-
-.fieldList .fieldListTop .clearSearchField,
-.clearSearchField.pentaho-deletebutton,
-.pentaho-deletebutton {
-  width: 22px;
-  height: 22px;
-  background: url('images/remove.png') no-repeat center;
-  cursor: pointer;
-  top: 0px;
-}
-
-.clearSearchField.pentaho-deletebutton.pentaho-imagebutton-disabled,
-.pentaho-deletebutton.pentaho-imagebutton-disabled {
-  width: 22px;
-  height: 22px;
-  background: url('images/remove_disabled.png') no-repeat center;
-  cursor: default;
-  top: 0px;
+.pentaho-addbutton.pentaho-imagebutton-disabled {
+  background-image: url('images/add_disabled.png');
 }
 
 .pentaho-datasourcebutton {
-  width: 22px;
-  height: 22px;
-  background: url('../images/datasource_sm.png') no-repeat center;
-  cursor: pointer;
-}
-
-.pentaho-closebutton.pentaho-imagebutton-hover {
-  width: 16px;
-  height: 16px;
-  background: url('images/closeTab_active.png') no-repeat center center;
-  cursor: pointer;
-}
-
-.pentaho-closebutton {
-  width: 16px;
-  height: 16px;
-  background: url('images/closeTab_active.png') no-repeat center center;
-  cursor: pointer;
-}
-
-.pentaho-closebutton.pentaho-imagebutton-disabled {
-  width: 16px;
-  height: 16px;
-  background: url('images/closeTab_off.png') no-repeat center center;
-  cursor: default;
+  background-image: url('images/database.png');
 }
 
 .pentaho-closebutton-big {
-  width: 20px;
-  height: 20px;
-  background: url('images/close_big.png') no-repeat center;
-  cursor: pointer;
+  --icon-height: 20;
+  --icon-width: 20;
+
   margin-top: 10px;
   margin-right: 10px;
+
+  background-image: url('images/close_big.png');
 }
 
-.pentaho-undobutton {
-  width: 16px;
-  height: 16px;
-  background: url('../images/undo.png') no-repeat center;
-  cursor: pointer;
+.pentaho-deletebutton {
+  background-image: url('images/remove.png');
+  top: 0;
+}
+:is(
+  .pentaho-deletebutton.clearSearchField,
+  .pentaho-deletebutton
+).pentaho-imagebutton-disabled {
+  background-image: url('images/remove_disabled.png');
 }
 
-.pentaho-undobutton.disabled,
-.pentaho-undobutton.pentaho-imagebutton-disabled {
-  width: 16px;
-  height: 16px;
-  background: url('../images/undo_disabled.png') no-repeat center;
-  cursor: default;
+.pentaho-editbutton {
+  background-image: url('images/edit_22.png');
+}
+.pentaho-editbutton.pentaho-imagebutton-disabled {
+  background-image: url('images/edit_22_disabled.png');
+}
+
+.pentaho-exportbutton {
+  background-image: url('images/file_export.png');
+}
+.pentaho-exportbutton.pentaho-imagebutton-disabled {
+  background-image: url('images/export_disabled.png');
+}
+
+.pentaho-newbutton-small {
+  background-image: url('images/new_22.png');
+}
+
+.pentaho-openbutton-small {
+  background-image: url('images/open_22.png');
 }
 
 .pentaho-redobutton {
-  width: 16px;
-  height: 16px;
-  background: url('../images/redo.png') no-repeat center;
+  background-image: url('images/redo.png');
+}
+.pentaho-redobutton:is(.disabled, .pentaho-imagebutton-disabled) {
+  background-image: url('images/redo-disabled.png');
+}
+
+.pentaho-saveasbutton-small {
+  background-image: url('images/saveas_22.png');
+}
+
+.pentaho-savebutton-small {
+  background-image: url('images/save_22.png');
+}
+
+.pentaho-undobutton {
+  background-image: url('images/undo.png');
+}
+.pentaho-undobutton:is(.disabled, .pentaho-imagebutton-disabled) {
+  background-image: url('images/undo_disable.png');
+}
+/* endregion */
+
+/* region Pentaho Buttons small size */
+.pentaho-backcolorbutton, .pentaho-closebutton, .pentaho-contextmenubutton,
+.pentaho-downbutton, .pentaho-filterbutton, .pentaho-forecolorbutton,
+.pentaho-layoutbutton, .pentaho-pagebackbutton, .pentaho-pagenextbutton,
+.pentaho-optionsbutton, .pentaho-upbutton {
+  --icon-height: 16;
+  --icon-width: 16;
+
+  height: calc(1px * var(--icon-height));
+  width: calc(1px * var(--icon-width));
+
+  background-repeat: no-repeat;
+  background-position: center;
   cursor: pointer;
 }
 
-.pentaho-redobutton.disabled,
-.pentaho-redobutton.pentaho-imagebutton-disabled {
-  width: 16px;
-  height: 16px;
-  background: url('../images/redo_disabled.png') no-repeat center;
-  cursor: default;
+.pentaho-backcolorbutton {
+  background-image: url('../images/back_color.png');
+}
+.pentaho-backcolorbutton.pentaho-imagebutton-disabled {
+  background-image: url('../images/back_color_disabled.png');
+}
+
+:is(
+  .pentaho-closebutton,
+  .pentaho-closebutton.pentaho-imagebutton-hover
+) {
+  background-image: url('images/closeTab_active.png');
+}
+.pentaho-closebutton.pentaho-imagebutton-disabled {
+  background-image: url('images/closeTab_off.png');
+}
+
+.pentaho-contextmenubutton {
+  --icon-height: 15;
+  --icon-width: 15;
+
+  background-image: url('../images/options_menu_arrow.png');
 }
 
 .pentaho-downbutton {
-  width: 16px;
-  height: 16px;
-  background: url('images/16x16_down.png') no-repeat center;
-  cursor: pointer;
+  background-image: url('images/16x16_down.png');
 }
-
 .pentaho-downbutton.pentaho-imagebutton-disabled {
-  width: 16px;
-  height: 16px;
-  background: url('images/16x16_down_disabled.png') no-repeat center;
-  cursor: default;
+  background-image: url('images/16x16_down_disabled.png');
 }
 
-.pentaho-upbutton {
-  width: 16px;
-  height: 16px;
-  background: url('images/16x16-up.png') no-repeat center;
-  cursor: pointer;
+.pentaho-filterbutton {
+  background-image: url('../images/filter.png');
+}
+.pentaho-filterbutton.pentaho-imagebutton-disabled {
+  background-image: url('../images/filter_disabled.png');
 }
 
-.pentaho-upbutton.pentaho-imagebutton-disabled {
-  width: 16px;
-  height: 16px;
-  background: url('images/16x16-up_disabled.png') no-repeat center;
-  cursor: default;
+.pentaho-forecolorbutton {
+  background-image: url('../images/font_color.png');
+}
+.pentaho-forecolorbutton.pentaho-imagebutton-disabled {
+  background-image: url('../images/font_color_disabled.png');
+}
+
+.pentaho-layoutbutton {
+  background-image: url('../images/field_layout.png');
 }
 
 .pentaho-optionsbutton {
-  width: 16px;
-  height: 16px;
-  background: url('../images/options.png') no-repeat center;
-  cursor: pointer;
+  background-image: url('../images/options.png');
+}
+.pentaho-optionsbutton.pentaho-imagebutton-disabled {
+  background-image: url('../images/options_disabled.png');
 }
 
-.pentaho-optionsbutton.pentaho-imagebutton-disabled {
-  width: 16px;
-  height: 16px;
-  background: url('../images/options_disabled.png') no-repeat center;
+.pentaho-pagebackbutton {
+  --icon-width: 18;
+  --icon-height: 18;
+
+  background-image: url('../images/page_back.png');
+}
+.pentaho-pagebackbutton.pentaho-imagebutton-hover {
+  background-image: url('../images/page_back_over.png');
+}
+.pentaho-pagebackbutton.pentaho-imagebutton-disabled {
+  background-image: url('../images/page_back_disabled.png');
+}
+
+.pentaho-pagenextbutton {
+  --icon-width: 18;
+  --icon-height: 18;
+
+  background-image: url('../images/page_forward.png');
+}
+.pentaho-pagenextbutton.pentaho-imagebutton-hover {
+  background-image: url('../images/page_forward_over.png');
+}
+.pentaho-pagenextbutton.pentaho-imagebutton-disabled {
+  background-image: url('../images/page_forward_disabled.png');
+}
+
+.pentaho-upbutton {
+  background-image: url('images/16x16-up.png');
+}
+.pentaho-upbutton.pentaho-imagebutton-disabled {
+  background-image: url('images/16x16-up_disabled.png');
+}
+/* endregion */
+
+.pentaho-imagebutton-disabled {
   cursor: default;
 }
+/* endregion */
 
-.prevTemplateIconOn,
-.pentaho-left-lgbutton {
-  width: 26px;
-  height: 33px;
+.prevTemplateIconOn, .pentaho-left-lgbutton {
+  --icon-height: 26;
+  --icon-width: 33;
+
+  height: calc(1px * var(--icon-height));
+  width: calc(1px * var(--icon-width));
+
   background: url('images/lg_arrow_left_on.png') no-repeat center;
   cursor: pointer;
 }
 
-.prevTemplateIconOff,
-.pentaho-left-lgbutton.pentaho-imagebutton-disabled {
-  width: 26px;
-  height: 33px;
+.prevTemplateIconOff, .pentaho-left-lgbutton.pentaho-imagebutton-disabled {
   background: url('images/lg_arrow_left_off.png') no-repeat center;
   cursor: default;
 }
 
-.nextTemplateIconOn,
-.pentaho-right-lgbutton {
+.nextTemplateIconOn, .pentaho-right-lgbutton {
   width: 26px;
   height: 33px;
   background: url('images/lg_arrow_right_on.png') no-repeat center;
   cursor: pointer;
 }
 
-.nextTemplateIconOff,
-.pentaho-right-lgbutton.pentaho-imagebutton-disabled {
-  width: 26px;
-  height: 33px;
+.nextTemplateIconOff, .pentaho-right-lgbutton.pentaho-imagebutton-disabled {
   background: url('images/lg_arrow_right_off.png') no-repeat center;
-  cursor: default;
-}
-
-.pentaho-forecolorbutton {
-  width: 16px;
-  height: 16px;
-  background: url('../images/font_color.png') no-repeat center;
-  cursor: pointer;
-}
-
-.pentaho-forecolorbutton.pentaho-imagebutton-disabled {
-  width: 16px;
-  height: 16px;
-  background: url('../images/font_color_disabled.png') no-repeat center;
-  cursor: default;
-}
-
-.pentaho-backcolorbutton {
-  width: 16px;
-  height: 16px;
-  background: url('../images/back_color.png') no-repeat center;
-  cursor: pointer;
-}
-
-.pentaho-backcolorbutton.pentaho-imagebutton-disabled {
-  width: 16px;
-  height: 16px;
-  background: url('../images/back_color_disabled.png') no-repeat center;
-  cursor: default;
-}
-
-.pentaho-filterbutton {
-  width: 16px;
-  height: 16px;
-  background: url('../images/filter.png') no-repeat center;
-  cursor: pointer;
-}
-
-.pentaho-filterbutton.pentaho-imagebutton-disabled {
-  width: 16px;
-  height: 16px;
-  background: url('../images/filter_disabled.png') no-repeat center;
-  cursor: default;
-}
-
-.pentaho-layoutbutton {
-  width: 16px;
-  height: 16px;
-  background: url('../images/field_layout.png') no-repeat center;
-  cursor: pointer;
-}
-
-.pentaho-contextmenubutton {
-  width: 15px;
-  height: 15px;
-  background: url('../images/options_menu_arrow.png') no-repeat center;
-  cursor: pointer;
-}
-
-.pentaho-pagebackbutton {
-  width: 18px;
-  height: 18px;
-  background: url('../images/page_back.png') no-repeat center;
-  cursor: pointer;
-}
-
-.pentaho-pagebackbutton.pentaho-imagebutton-hover {
-  width: 18px;
-  height: 18px;
-  background: url('../images/page_back_over.png') no-repeat center;
-  cursor: pointer;
-}
-
-.pentaho-pagebackbutton.pentaho-imagebutton-disabled {
-  width: 18px;
-  height: 18px;
-  background: url('../images/page_back_disabled.png') no-repeat center;
-  cursor: default;
-}
-
-.pentaho-pagenextbutton {
-  width: 18px;
-  height: 18px;
-  background: url('../images/page_forward.png') no-repeat center;
-  cursor: pointer;
-}
-
-.pentaho-pagenextbutton.pentaho-imagebutton-hover {
-  width: 18px;
-  height: 18px;
-  background: url('../images/page_forward_over.png') no-repeat center;
-  cursor: pointer;
-}
-
-.pentaho-pagenextbutton.pentaho-imagebutton-disabled {
-  width: 18px;
-  height: 18px;
-  background: url('../images/page_forward_disabled.png') no-repeat center;
   cursor: default;
 }
 
@@ -4154,12 +4074,17 @@ div.dijitDateTextBox.dijitComboBox {
   background-repeat: no-repeat;
 }
 
-.refresh-browse-perspective,
-.icon-small.icon-refresh {
-  background: url('images/refresh-small.png');
-  height: 22px;
-  width: 22px;
+.refresh-browse-perspective, .icon-small.icon-refresh {
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
+
+  background-image: url('images/refresh-small.png');
   cursor: pointer;
+}
+
+.refresh-browse-perspective:where(:not(.icon-zoomable)) {
+  height: calc(1px * var(--icon-height));
+  width: calc(1px * var(--icon-width));
 }
 
 .icon-small.icon-refresh.disabled {
@@ -4167,27 +4092,25 @@ div.dijitDateTextBox.dijitComboBox {
 }
 
 .icon-small.icon-run {
-  background: url('images/start-scheduler-small.png');
-  height: 22px;
-  width: 22px;
+  --icon-height: 22;
+  --icon-width: 22;
+
+  background-image: url('images/start-scheduler-small.png');
 }
 
 .icon-small.icon-run.disabled {
   background: url('images/start-scheduler-small.png');
-  height: 22px;
-  width: 22px;
 }
 
 .icon-small.icon-open-folder {
-  background: url('images/open-folder.png');
-  height: 22px;
-  width: 22px;
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
+
+  background-image: url('images/open-folder.png');
 }
 
 .icon-small.icon-open-folder.disabled {
   background: url('images/open-folder-disabled.png');
-  height: 22px;
-  width: 22px;
 }
 
 .icon-small.icon-update {
@@ -4215,34 +4138,43 @@ div.dijitDateTextBox.dijitComboBox {
 }
 
 .icon-small.icon-analysis {
-  background: url('images/file_analysis.png') no-repeat;
-  height: 22px;
-  width: 22px;
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
+
+  background-image: url('images/file_analysis.png');
+  background-repeat: no-repeat;
 }
 
 .icon-small.icon-xaction {
-  background: url('images/file_action.png') no-repeat;
-  height: 22px;
-  width: 22px;
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
+
+  background-image: url('images/file_action.png');
+  background-repeat: no-repeat;
 }
 
 .icon-small.icon-url {
-  background: url('images/file_url.png') no-repeat;
-  height: 22px;
-  width: 22px;
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
+
+  background-image: url('images/file_url.png');
+  background-repeat: no-repeat;
 }
 
 .icon-small.icon-file {
-  background: url('images/file.png') no-repeat;
-  height: 22px;
-  width: 22px;
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
+
+  background-image: url('images/file.png');
+  background-repeat: no-repeat;
 }
 
 .icon-small.icon-folder {
-  --icon-height: 22;
-  --icon-width: 22;
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
 
-  background: url('images/folder_closed.png') no-repeat;
+  background-image: url('images/folder_closed.png');
+  background-repeat: no-repeat;
 }
 
 .fileChooser {
@@ -4264,75 +4196,93 @@ div.dijitDateTextBox.dijitComboBox {
 }
 
 .icon-small.icon-waqr-report {
-  background: url('images/file_generic.png') no-repeat;
-  height: 22px;
-  width: 22px;
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
+
+  background-image: url('images/file_generic.png');
+  background-repeat: no-repeat;
 }
 
 .icon-small.icon-analyzer {
-  background: url('images/file_analysis.png') no-repeat;
-  height: 22px;
-  width: 22px;
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
+
+  background-image: url('images/file_analysis.png');
+  background-repeat: no-repeat;
 }
 
 .icon-small.icon-pir-report {
-  background: url('images/prptiFile.png') no-repeat;
-  height: 22px;
-  width: 22px;
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
+
+  background-image: url('images/prptiFile.png');
+  background-repeat: no-repeat;
 }
 
 .icon-small.icon-prpt-report {
-  background: url('images/prptFile.png') no-repeat;
-  height: 22px;
-  width: 22px;
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
+
+  background-image: url('images/prptFile.png');
+  background-repeat: no-repeat;
 }
 
 .icon-small.icon-dashboard {
-  background: url('images/file_dashboard.png') no-repeat;
-  height: 22px;
-  width: 22px;
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
+
+  background-image: url('images/file_dashboard.png');
+  background-repeat: no-repeat;
 }
 
 .icon-small.icon-stop {
-  background: url('images/stop_scheduler.png') no-repeat;
-  height: 22px;
-  width: 22px;
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
+
+  background-image: url('images/stop_scheduler.png');
+  background-repeat: no-repeat;
 }
 
 .icon-small.icon-stop-scheduler {
-  background: url('images/power-on.png');
-  height: 22px;
-  width: 22px;
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
+
+  background-image: url('images/power-on.png');
 }
 
 .icon-small.icon-start-scheduler {
-  background: url('images/power-off.png');
-  height: 22px;
-  width: 22px;
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
+
+  background-image: url('images/power-off.png');
 }
 
 .icon-small.icon-execute {
-  background: url('images/run-now.png');
-  height: 22px;
-  width: 22px;
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
+
+  background-image: url('images/run-now.png');
 }
 
 .icon-small.icon-filter-add {
-  background: url('images/filter-add-small.png');
-  height: 22px;
-  width: 22px;
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
+
+  background-image: url('images/filter-add-small.png');
 }
 
 .icon-small.icon-filter-active {
-  background: url('../images/filter-active-small.png');
-  height: 22px;
-  width: 22px;
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
+
+  background-image: url('../images/filter-active-small.png');
 }
 
 .icon-small.icon-filter-remove {
-  background: url('images/filter-remove-small.png');
-  height: 22px;
-  width: 22px;
+  --icon-height: var(--icon-height-root);
+  --icon-width: var(--icon-width-root);
+
+  background-image: url('images/filter-remove-small.png');
 }
 
 .icon-medium.icon-open {
@@ -4393,27 +4343,31 @@ div.dijitDateTextBox.dijitComboBox {
 }
 
 .icon-small.icon-accum-add {
-  background: url('images/accum_add.png');
-  height: 13px;
-  width: 14px;
+  --icon-height: 13;
+  --icon-width: 14;
+
+  background-image: url('images/accum_add.png');
 }
 
 .icon-small.icon-accum-add-all {
-  background: url('images/accum_add_all.png');
-  height: 13px;
-  width: 14px;
+  --icon-height: 13;
+  --icon-width: 14;
+
+  background-image: url('images/accum_add_all.png');
 }
 
 .icon-small.icon-accum-remove {
-  background: url('images/accum_remove.png');
-  height: 13px;
-  width: 14px;
+  --icon-height: 13;
+  --icon-width: 14;
+
+  background-image: url('images/accum_remove.png');
 }
 
 .icon-small.icon-accum-remove-all {
-  background: url('images/accum_remove_all.png');
-  height: 13px;
-  width: 14px;
+  --icon-height: 13;
+  --icon-width: 14;
+
+  background-image: url('images/accum_remove_all.png');
 }
 
 .icon-tree-leaf {
@@ -6716,32 +6670,6 @@ span.gwt-RadioButton label {
   width: 35px;
 }
 
-.pentaho-undobutton {
-  background: url('images/undo.png') no-repeat;
-  width: 22px;
-  height: 22px;
-}
-
-.pentaho-undobutton.disabled,
-.pentaho-undobutton.pentaho-imagebutton-disabled {
-  background: url('images/undo_disable.png') no-repeat;
-  width: 22px;
-  height: 22px;
-}
-
-.pentaho-redobutton.disabled,
-.pentaho-redobutton.pentaho-imagebutton-disabled {
-  background: url('images/redo-disabled.png') no-repeat;
-  width: 22px;
-  height: 22px;
-}
-
-.pentaho-redobutton {
-  background: url('images/redo.png') no-repeat;
-  width: 22px;
-  height: 22px;
-}
-
 .field-panel-icon {
   background: url('images/field_panel.png') no-repeat;
   width: 22px;
@@ -7117,10 +7045,6 @@ span.gwt-RadioButton label {
   border: 1px solid #CC0000;
 }
 
-.pentaho-datasourcebutton {
-  background: url('images/database.png') no-repeat;
-}
-
 #toolbar2a {
   background-color: #FFF;
 }
@@ -7150,18 +7074,6 @@ span.gwt-RadioButton label {
 }
 
 /* ----------  data access ----------  */
-.pentaho-exportbutton {
-  background: url('images/file_export.png') no-repeat;
-}
-
-.pentaho-exportbutton.pentaho-imagebutton-disabled {
-  background: url('images/export_disabled.png') no-repeat;
-}
-
-.pentaho-addcombobutton {
-  background: url('images/add_combo.png') no-repeat;
-}
-
 #filterTypeDeck #staticSelectionTableEditSelected img.disabled-image-button-pressed,
 #filterTypeDeck #staticSelectionTableEditSelected img.disabled-image-button-over,
 #filterTypeDeck #staticSelectionTableEditSelected img.disabled-image-button,


### PR DESCRIPTION
@pentaho/wcag @pentaho/millenniumfalcon please review

**NOTE:** Can only be merged after https://github.com/pentaho/pentaho-commons-gwt-modules/pull/882
  - The first two commits are from this PR, so please ignore them in your reviews
 
This cleanup focused on removing hardcoded `widths/heights` and making use of the new variables `--icon-height`, `--icon-width` and `--icon-...-root`, as well expanding `background` shorthand styles to make it easier to use the new style `icon-zoomable`.