### PR TITLE
[BACKLOG-37323] - [SAFARI]The focus ring is not coming up on the 'File Options' under the 'Browse Files'

### DIFF
--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/ruby/globalRuby.css
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/ruby/globalRuby.css
@@ -4908,6 +4908,10 @@ div.dijitDateTextBox.dijitComboBox {
   text-decoration: underline;
 }
 
+.bootstrap #fileBrowserButtons.fileBrowserColumn .btn:focus-visible {
+  box-shadow: 0 0 transparent;
+}
+
 .bootstrap #fileBrowserButtons.fileBrowserColumn .btn[disabled],
 .bootstrap #fileBrowserButtons.fileBrowserColumn .btn[disabled]:link,
 .bootstrap #fileBrowserButtons.fileBrowserColumn .btn[disabled]:visited,


### PR DESCRIPTION
@pentaho/wcag , Please review.

There is a limitation with outline and border-radius with safari. Reference links for the fix: 
https://github.com/google/model-viewer/issues/662
https://github.com/juliocodes-sm/Reels/pull/2