### PR TITLE
[BACKLOG-37873] Normalized `label` element color in active global styles

### DIFF
--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/ruby/globalRuby.css
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/ruby/globalRuby.css
@@ -199,6 +199,11 @@ label {
   font-size: 13px;
 }
 
+label,
+.gwt-Label {
+  color: #414141;
+}
+
 div.pentaho-dialog.schedule-recurrence-dialog label {
   font-size: 14px;
 }
@@ -363,10 +368,6 @@ select option:hover {
 
 .IE .scheduleEditor FIELDSET TD {
   padding-top: 0px !important;
-}
-
-.gwt-Label {
-  color: #414141;
 }
 
 .adminField {

--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
@@ -83,6 +83,11 @@ label {
   font-size: 13px;
 }
 
+label,
+.gwt-Label {
+  color: #666;
+}
+
 div.pentaho-dialog.schedule-recurrence-dialog label {
   font-size: 14px;
 }
@@ -225,10 +230,6 @@ select option,
 
 .IE .scheduleEditor FIELDSET TD {
   padding-top: 0px !important;
-}
-
-.gwt-Label {
-  color: #666;
 }
 
 *:focus {


### PR DESCRIPTION
Story/Task: [BACKLOG-38649](https://hv-eng.atlassian.net/browse/BACKLOG-38649)

/cc @pentaho/hoth 

Part of PR set: https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/28

- Made `label` have the same color as other label classes (e.g. `gwt-Label`)



[BACKLOG-38649]: https://hv-eng.atlassian.net/browse/BACKLOG-38649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ