### PR TITLE
[BACKLOG-37873][BACKLOG-38655] Centralize some responsive primitives across themes

### DIFF
--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes.xml
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <themes root-folder="resources/themes">
-  <ruby display-name="Ruby" system="true">
+  <ruby display-name="Ruby" system="true" responsive="true">
+    <file>../base.css</file>
     <file>globalRuby.css</file>
     <file>bootstrap/css/bootstrap-namespaced.css</file>
   </ruby>
@@ -9,10 +10,12 @@
     <file>bootstrap/css/bootstrap-namespaced.css</file>
   </onyx>
   <crystal display-name="Crystal" system="true">
+    <file>../base.css</file>
     <file>globalCrystal.css</file>
     <file>bootstrap/css/bootstrap-namespaced.css</file>
   </crystal>
   <sapphire display-name="Sapphire" system="true">
+    <file>../base.css</file>
     <file>globalSapphire.css</file>
     <file>bootstrap/css/bootstrap-namespaced.css</file>
   </sapphire>

--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/base.css
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/base.css
@@ -1,0 +1,190 @@
+:root {
+  /* FOCUS RING */
+  --focus-ring-width: 3px;
+  --focus-ring: var(--focus-ring-width) solid #0075ff;
+
+  /* The default `outline-offset` should cause the outline to hide the border of most elements,
+     and, at the same time, not cause the outline to overflow the parent and be clipped.
+     If needed, adjust the `outline-offset` for specific elements or element types.
+   */
+  --focus-ring-offset: 2px;
+
+  /* How much space the focus ring takes beyond an element's border-box to be fully visible (focus-ring-width + focus-ring-offset).
+  To be used to ensure enough padding for focus outlines on containers having an overflow of hidden or auto. */
+  --focus-ring-padding: 5px;
+
+  /* ACCESSIBILITY */
+  /* Minimum width for a WCAG accessible vertical scrolling layout. */
+  --a11y-min-width: 320px;
+
+  /* Minimum height for a WCAG accessible horizontal scrolling layout. */
+  --a11y-min-height: 256px;
+
+  /* DIALOG GLOBAL variables */
+  --dialog-border-width: 1px;
+
+  /* Padding, on each side */
+  --dialog-padding: 20px;
+
+  /* Design System min/safe margin, on each side */
+  --dialog-ds-min-margin-h: calc(100% / 12);
+  --dialog-ds-min-margin-v: 80px;
+
+  /* LAYOUT GLOBAL */
+  --typ-body-font-size-px: 14;
+  --typ-body-line-height-px: 17;
+  --typ-body-font-size: calc(1px * var(--typ-body-font-size-px));
+  --typ-body-line-height: calc(1px * var(--typ-body-line-height-px));
+
+
+  --text-block-max-width: 75ch;
+
+  /* Set H and V space between layout cols and rows.
+     Or, use the helper classes: .with-layout-gap-... for predefined values.
+     Use current values on CSS properties using .gap-...
+     Root variables should only be changed at root.
+     The other two variables can be changed at any element and will be inherited by all descendants.
+   */
+  --layout-gap-h-root: 8px;
+  --layout-gap-v-root: 6px;
+
+  --layout-gap-h: var(--layout-gap-h-root);
+  --layout-gap-v: var(--layout-gap-v-root);
+}
+
+@media (max-height: 720px) {
+  :root {
+    --dialog-ds-min-margin-v: 40px;
+  }
+}
+
+/* region Responsive Primitives */
+
+/* In below selectors, using * and/or :where(.) where possible to keep specificity as low as possible. */
+
+/* Responsive Classes
+ * - .responsive-theme -- Indicates the theme is responsive.
+ * - .responsive -- Within a `.responsive-theme`, indicates an element subtree which should be rendered responsively.
+ *                  Typically, these are elements whose markup has fixed dimensions, which the responsive styles
+ *                  override.
+ * - .responsive-content -- Indicates content which is "natively" responsive, irrespective of the theme being responsive.
+ */
+
+/* region .with-layout-gap- ... */
+/* Classes for setting the value of the --layout-gap-h and --layout-gap-v variables to predefined values
+   for an element's sub-tree. For _later_ use on the CSS gap, column-gap and row-gap properties, on other rules.
+*/
+.with-layout-gap-none {
+  --layout-gap-h: 0;
+  --layout-gap-v: 0;
+}
+
+.with-layout-gap-h-none {
+  --layout-gap-h: 0;
+}
+
+.with-layout-gap-v-none {
+  --layout-gap-v: 0;
+}
+
+.with-layout-gap-normal {
+  --layout-gap-h: var(--layout-gap-h-root);
+  --layout-gap-v: var(--layout-gap-v-root);
+}
+
+.with-layout-gap-h-normal {
+  --layout-gap-h: var(--layout-gap-h-root);
+}
+
+.with-layout-gap-v-normal {
+  --layout-gap-v: var(--layout-gap-v-root);
+}
+/* endregion */
+
+/* region flex-row / flex-column */
+:where(.responsive-theme .responsive, .responsive-content):is(.flex-column, .flex-row),
+:where(.responsive-theme .responsive, .responsive-content) :is(.flex-column, .flex-row) {
+  flex: auto;
+  display: flex;
+  gap: var(--layout-gap-v) var(--layout-gap-h);
+}
+
+:where(.responsive-theme .responsive, .responsive-content).flex-row,
+:where(.responsive-theme .responsive, .responsive-content) .flex-row {
+  flex-direction: row;
+}
+
+/* Add to the flex row element when it has a flex item with a H-scrollbar,
+   to allow the child's scrollbar to work.
+ */
+:where(.responsive-theme .responsive, .responsive-content).flex-row:where(.with-scroll-child),
+:where(.responsive-theme .responsive, .responsive-content) .flex-row:where(.with-scroll-child) {
+  min-width: 0;
+}
+
+:where(.responsive-theme .responsive, .responsive-content).flex-column,
+:where(.responsive-theme .responsive, .responsive-content) .flex-column {
+  flex-direction: column;
+}
+
+/* Add to the flex column element when it has a flex item with a V-scrollbar,
+   to allow the child's scrollbar to work.
+ */
+:where(.responsive-theme .responsive, .responsive-content).flex-column:where(.with-scroll-child),
+:where(.responsive-theme .responsive, .responsive-content) .flex-column:where(.with-scroll-child) {
+  min-height: 0;
+}
+
+/* Items having same direction of the container inherit its flex by default.
+   When changing direction, the container's default flex of auto is used by default.
+ */
+:where(.responsive-theme .responsive, .responsive-content).flex-row > :where(.flex-row),
+:where(.responsive-theme .responsive, .responsive-content) .flex-row > :where(.flex-row),
+:where(.responsive-theme .responsive, .responsive-content).flex-column > :where(.flex-column),
+:where(.responsive-theme .responsive, .responsive-content) .flex-column > :where(.flex-column) {
+  flex: inherit;
+}
+/* endregion Responsive Primitives */
+
+/* region Modifiers: gap-, flex-, ... */
+/* Placed after other primitives, to override them. */
+
+/* Classes for setting the CSS properties gap, column-gap and/or row-gap
+   with predefined values on the current element.
+ */
+.gap-none {
+  gap: 0;
+}
+
+.gap-h-none {
+  column-gap: 0;
+}
+
+.gap-v-none {
+  row-gap: 0;
+}
+
+.gap-layout {
+  gap: var(--layout-gap-v) var(--layout-gap-h);
+}
+
+.gap-h-layout {
+  column-gap: var(--layout-gap-h);
+}
+
+.gap-v-layout {
+  row-gap: var(--layout-gap-v);
+}
+
+.flex-none {
+  flex: none;
+}
+
+.flex-auto {
+  flex: auto;
+}
+
+.flex-wrap {
+  flex-wrap: wrap;
+}
+/* endregion */

--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
@@ -631,7 +631,143 @@ div#data-controlproperties-spacer {
   display: none;
 }
 
-  /* Find a home for these */
+
+/* region DIALOG RESPONSIVE - BEGIN */
+/* Adapted from globalRuby.css, by replacing `.responsive` with `.responsive-content.` Keep in sync with it. */
+:where(.responsive-content).pentaho-dialog {
+  --dialog-max-width: 100vw;
+  --dialog-max-height: 100vh;
+  --dialog-min-width: var(--a11y-min-width);
+  --dialog-min-height: var(--a11y-min-height);
+  --priv-dialog-borders-paddings: calc( 2 * var(--dialog-padding) + 2 * var(--dialog-border-width));
+
+  box-sizing: border-box;
+
+  display: flex;
+  flex-direction: column;
+  overflow-x: hidden;
+  overflow-y: auto;
+
+  max-width: clamp(
+      var(--dialog-min-width),
+      calc(100vw - 2 * var(--dialog-ds-min-margin-h)),
+      var(--dialog-max-width));
+
+  max-height: min(
+      clamp(
+          var(--dialog-min-height),
+          calc(100vh - 2 * var(--dialog-ds-min-margin-v)),
+          var(--dialog-max-height)),
+      100vh);
+
+  padding: 0;
+}
+
+:where(.responsive-content).pentaho-dialog > * {
+  flex: auto;
+  display: flex;
+  flex-direction: column;
+
+  min-width: calc(var(--dialog-min-width) - 2 * var(--dialog-border-width));
+  min-height: calc(var(--dialog-min-height) - 2 * var(--dialog-border-width));
+}
+
+@media (max-height: 256px) {
+  :where(.responsive-content).pentaho-dialog > * {
+    min-height: auto;
+  }
+}
+
+:where(.responsive-content).pentaho-dialog:where(.dmh-content) > * {
+  min-height: auto;
+}
+
+:where(.responsive-content).pentaho-dialog:where(.ds-fill-viewport-width),
+:where(.responsive-content).pentaho-dialog:where(.ds-fill-viewport),
+:where(.responsive-content).pentaho-dialog:where(.ds-full-viewport) {
+  width: 100%;
+}
+
+:where(.responsive-content).pentaho-dialog:where(.ds-fill-viewport),
+:where(.responsive-content).pentaho-dialog:where(.ds-full-viewport) {
+  height: 100%;
+}
+
+:where(.responsive-content).pentaho-dialog:where(.ds-full-viewport) {
+  max-width: 100%;
+  max-height: 100%;
+}
+
+:where(.responsive-content).pentaho-dialog:where(.dw-min) {
+  --dialog-max-width: var(--a11y-min-width);
+}
+
+:where(.responsive-content).pentaho-dialog:where(.dw-text) {
+  --dialog-max-width: calc(var(--text-block-max-width) + var(--priv-dialog-borders-paddings));
+}
+
+:where(.responsive-content).pentaho-dialog:where(.dw-xs) {
+  --dialog-max-width: 448px;
+}
+
+:where(.responsive-content).pentaho-dialog:where(.dw-sm) {
+  --dialog-max-width: 672px;
+}
+
+:where(.responsive-content).pentaho-dialog:where(.dw-md) {
+  --dialog-max-width: 880px;
+}
+
+:where(.responsive-content).pentaho-dialog:where(.dw-lg) {
+  --dialog-max-width: 1096px;
+}
+
+:where(.responsive-content).pentaho-dialog:where(.dw-xl) {
+  --dialog-max-width: 1300px;
+}
+
+:where(.responsive-content).pentaho-dialog .Caption {
+  flex: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: var(--dialog-padding);
+}
+
+:where(.responsive-content).pentaho-dialog .dialog-content {
+  flex: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+  padding: var(--focus-ring-padding) var(--dialog-padding) var(--dialog-padding) !important;
+  height: auto !important;
+  width: auto !important;
+  gap: var(--layout-gap-v) var(--layout-gap-h);
+}
+
+:where(.responsive-content).pentaho-dialog .button-panel {
+  flex: none;
+  overflow: hidden;
+  width: unset;
+  margin: 0;
+  padding: var(--dialog-padding);
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+  justify-content: end;
+  gap: var(--layout-gap-v) var(--layout-gap-h);
+}
+
+:where(.responsive-content).pentaho-dialog .button-panel .pentaho-button {
+  flex: 0 1 auto;
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+/* endregion DIALOG RESPONSIVE - END */
+
+/* Find a home for these */
 .login-dialog {
   z-index: 2000;
 }

--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/ruby/globalRuby.css
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/ruby/globalRuby.css
@@ -39,57 +39,7 @@
 }
 
 :root {
-  /* FOCUS RING */
-  --focus-ring-width: 3px;
-  --focus-ring: var(--focus-ring-width) solid #0075ff;
-
-  /* The default `outline-offset` should cause the outline to hide the border of most elements,
-     and, at the same time, not cause the outline to overflow the parent and be clipped.
-     If needed, adjust the `outline-offset` for specific elements or element types.
-   */
-  --focus-ring-offset: 2px;
-
-  /* How much space the focus ring takes beyond an element's border-box to be fully visible (focus-ring-width + focus-ring-offset).
-  To be used to ensure enough padding for focus outlines on containers having an overflow of hidden or auto. */
-  --focus-ring-padding: 5px;
-
-  /* ACCESSIBILITY */
-  /* Minimum width for a WCAG accessible vertical scrolling layout. */
-  --a11y-min-width: 320px;
-
-  /* Minimum height for a WCAG accessible horizontal scrolling layout. */
-  --a11y-min-height: 256px;
-
-  /* DIALOG GLOBAL variables */
-  --dialog-border-width: 1px;
-
-  /* Padding, on each side */
-  --dialog-padding: 20px;
-
-  /* Design System min/safe margin, on each side */
-  --dialog-ds-min-margin-h: calc(100% / 12);
-  --dialog-ds-min-margin-v: 80px;
-
   /* LAYOUT GLOBAL */
-  --text-block-max-width: 75ch;
-
-  --typ-body-font-size-px: 14;
-  --typ-body-line-height-px: 17;
-  --typ-body-font-size: calc(1px * var(--typ-body-font-size-px));
-  --typ-body-line-height: calc(1px * var(--typ-body-line-height-px));
-
-  /* Set H and V space between layout cols and rows.
-     Or, use the helper classes: .with-layout-gap-... for predefined values.
-     Use current values on CSS properties using .gap-...
-     Root variables should only be changed at root.
-     The other two variables can be changed at any element and will be inherited by all descendants.
-   */
-  --layout-gap-h-root: 8px;
-  --layout-gap-v-root: 6px;
-
-  --layout-gap-h: var(--layout-gap-h-root);
-  --layout-gap-v: var(--layout-gap-v-root);
-
   /* Input height resizes with text zoom, as it is based on font size and line height.
      --input-outer-height = 33
         = 2 x border + 2 x vertical-padding + line-height
@@ -112,12 +62,6 @@
 
   --icon-height: var(--icon-height-root);
   --icon-width: var(--icon-width-root);
-}
-
-@media (max-height: 720px) {
-  :root {
-    --dialog-ds-min-margin-v: 40px;
-  }
 }
 
 html,
@@ -964,84 +908,6 @@ div#FilterPanel div.pentaho-toggle-button-up button {
 
 /* region Responsive Primitives */
 
-/* In below selectors, using * and/or :where(.) where possible to keep specificity as low as possible. */
-
-/* region .with-layout-gap- ... */
-/* Classes for setting the value of the --layout-gap-h and --layout-gap-v variables to predefined values
-   for an element's sub-tree. For _later_ use on the CSS gap, column-gap and row-gap properties, on other rules.
-*/
-.with-layout-gap-none {
-  --layout-gap-h: 0;
-  --layout-gap-v: 0;
-}
-
-.with-layout-gap-h-none {
-  --layout-gap-h: 0;
-}
-
-.with-layout-gap-v-none {
-  --layout-gap-v: 0;
-}
-
-.with-layout-gap-normal {
-  --layout-gap-h: var(--layout-gap-h-root);
-  --layout-gap-v: var(--layout-gap-v-root);
-}
-
-.with-layout-gap-h-normal {
-  --layout-gap-h: var(--layout-gap-h-root);
-}
-
-.with-layout-gap-v-normal {
-  --layout-gap-v: var(--layout-gap-v-root);
-}
-/* endregion */
-
-/* region flex-row / flex-column */
-:where(.responsive):is(.flex-column, .flex-row),
-:where(.responsive) :is(.flex-column, .flex-row) {
-  flex: auto;
-  display: flex;
-  gap: var(--layout-gap-v) var(--layout-gap-h);
-}
-
-:where(.responsive).flex-row,
-:where(.responsive) .flex-row {
-  flex-direction: row;
-}
-
-/* Add to the flex row element when it has a flex item with a H-scrollbar,
-   to allow the child's scrollbar to work.
- */
-:where(.responsive).flex-row:where(.with-scroll-child),
-:where(.responsive) .flex-row:where(.with-scroll-child) {
-  min-width: 0;
-}
-
-:where(.responsive).flex-column,
-:where(.responsive) .flex-column {
-  flex-direction: column;
-}
-
-/* Add to the flex column element when it has a flex item with a V-scrollbar,
-   to allow the child's scrollbar to work.
- */
-:where(.responsive).flex-column:where(.with-scroll-child),
-:where(.responsive) .flex-column:where(.with-scroll-child) {
-  min-height: 0;
-}
-
-/* Items having same direction of the container inherit its flex by default.
-   When changing direction, the container's default flex of auto is used by default.
- */
-:where(.responsive).flex-row > :where(.flex-row),
-:where(.responsive) .flex-row > :where(.flex-row),
-:where(.responsive).flex-column > :where(.flex-column),
-:where(.responsive) .flex-column > :where(.flex-column) {
-  flex: inherit;
-}
-/* endregion */
-
 /* region GWT HorizontalFlexPanel, VerticalFlexPanel */
 :where(.responsive) .gwt-h-v-panel {
   /* Panel structure:
@@ -1107,35 +973,7 @@ div#FilterPanel div.pentaho-toggle-button-up button {
 /* endregion */
 
 /* region Modifiers: gap-, flex-, ... */
-/* Placed after other primitives, to override them. */
-
-/* Classes for setting the CSS properties gap, column-gap and/or row-gap
-   with predefined values on the current element.
- */
-.gap-none {
-  gap: 0;
-}
-
-.gap-h-none {
-  column-gap: 0;
-}
-
-.gap-v-none {
-  row-gap: 0;
-}
-
-.gap-layout {
-  gap: var(--layout-gap-v) var(--layout-gap-h);
-}
-
-.gap-h-layout {
-  column-gap: var(--layout-gap-h);
-}
-
-.gap-v-layout {
-  row-gap: var(--layout-gap-v);
-}
-
+/* Need to duplicate this here, from base.css, so that these may override the above GWT flex panel rules */
 .flex-none {
   flex: none;
 }

--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
@@ -1035,6 +1035,141 @@ button#schedule-dialog-select-button {
   height: 33px;
 }
 
+/* region DIALOG RESPONSIVE - BEGIN */
+/* Adapted from globalRuby.css, by replacing `.responsive` with `.responsive-content.` Keep in sync with it. */
+:where(.responsive-content).pentaho-dialog {
+  --dialog-max-width: 100vw;
+  --dialog-max-height: 100vh;
+  --dialog-min-width: var(--a11y-min-width);
+  --dialog-min-height: var(--a11y-min-height);
+  --priv-dialog-borders-paddings: calc( 2 * var(--dialog-padding) + 2 * var(--dialog-border-width));
+
+  box-sizing: border-box;
+
+  display: flex;
+  flex-direction: column;
+  overflow-x: hidden;
+  overflow-y: auto;
+
+  max-width: clamp(
+      var(--dialog-min-width),
+      calc(100vw - 2 * var(--dialog-ds-min-margin-h)),
+      var(--dialog-max-width));
+
+  max-height: min(
+      clamp(
+          var(--dialog-min-height),
+          calc(100vh - 2 * var(--dialog-ds-min-margin-v)),
+          var(--dialog-max-height)),
+      100vh);
+
+  padding: 0;
+}
+
+:where(.responsive-content).pentaho-dialog > * {
+  flex: auto;
+  display: flex;
+  flex-direction: column;
+
+  min-width: calc(var(--dialog-min-width) - 2 * var(--dialog-border-width));
+  min-height: calc(var(--dialog-min-height) - 2 * var(--dialog-border-width));
+}
+
+@media (max-height: 256px) {
+  :where(.responsive-content).pentaho-dialog > * {
+    min-height: auto;
+  }
+}
+
+:where(.responsive-content).pentaho-dialog:where(.dmh-content) > * {
+  min-height: auto;
+}
+
+:where(.responsive-content).pentaho-dialog:where(.ds-fill-viewport-width),
+:where(.responsive-content).pentaho-dialog:where(.ds-fill-viewport),
+:where(.responsive-content).pentaho-dialog:where(.ds-full-viewport) {
+  width: 100%;
+}
+
+:where(.responsive-content).pentaho-dialog:where(.ds-fill-viewport),
+:where(.responsive-content).pentaho-dialog:where(.ds-full-viewport) {
+  height: 100%;
+}
+
+:where(.responsive-content).pentaho-dialog:where(.ds-full-viewport) {
+  max-width: 100%;
+  max-height: 100%;
+}
+
+:where(.responsive-content).pentaho-dialog:where(.dw-min) {
+  --dialog-max-width: var(--a11y-min-width);
+}
+
+:where(.responsive-content).pentaho-dialog:where(.dw-text) {
+  --dialog-max-width: calc(var(--text-block-max-width) + var(--priv-dialog-borders-paddings));
+}
+
+:where(.responsive-content).pentaho-dialog:where(.dw-xs) {
+  --dialog-max-width: 448px;
+}
+
+:where(.responsive-content).pentaho-dialog:where(.dw-sm) {
+  --dialog-max-width: 672px;
+}
+
+:where(.responsive-content).pentaho-dialog:where(.dw-md) {
+  --dialog-max-width: 880px;
+}
+
+:where(.responsive-content).pentaho-dialog:where(.dw-lg) {
+  --dialog-max-width: 1096px;
+}
+
+:where(.responsive-content).pentaho-dialog:where(.dw-xl) {
+  --dialog-max-width: 1300px;
+}
+
+:where(.responsive-content).pentaho-dialog .Caption {
+  flex: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: var(--dialog-padding);
+}
+
+:where(.responsive-content).pentaho-dialog .dialog-content {
+  flex: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+  padding: var(--focus-ring-padding) var(--dialog-padding) var(--dialog-padding) !important;
+  height: auto !important;
+  width: auto !important;
+  gap: var(--layout-gap-v) var(--layout-gap-h);
+}
+
+:where(.responsive-content).pentaho-dialog .button-panel {
+  flex: none;
+  overflow: hidden;
+  width: unset;
+  margin: 0;
+  padding: var(--dialog-padding);
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+  justify-content: end;
+  gap: var(--layout-gap-v) var(--layout-gap-h);
+}
+
+:where(.responsive-content).pentaho-dialog .button-panel .pentaho-button {
+  flex: 0 1 auto;
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+/* endregion DIALOG RESPONSIVE - END */
+
 /* Find a home for these */
 .login-dialog {
   z-index: 2000;


### PR DESCRIPTION
- Plus added responsive dialog CSS styles to crystal and sapphire themes under the `responsive-content` CSS class
- For consistency, updated `themes.xml`, even though the version used by the server is that of common-ui

Part of PR set: https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/41

/cc @pentaho/hoth