### PR TITLE
[BACKLOG-37872] Changed Select Folder dialog to get data from Generic File Service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 
   <properties>
     <license.licenseName>lgpl_v2_1</license.licenseName>
+    <com.github.spotbugs.annotations.version>4.2.3</com.github.spotbugs.annotations.version>
   </properties>
 
   <scm>
@@ -101,7 +102,13 @@
         <version>1.0.0.GA</version>
         <classifier>sources</classifier>
       </dependency>
-
+      <dependency>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-annotations</artifactId>
+        <version>${com.github.spotbugs.annotations.version}</version>
+        <scope>provided</scope>
+        <optional>true</optional>
+      </dependency>
       <!-- Test -->
       <dependency>
         <groupId>com.google.gwt.gwtmockito</groupId>

--- a/widgets/pom.xml
+++ b/widgets/pom.xml
@@ -58,6 +58,10 @@
       <groupId>com.google.jsinterop</groupId>
       <artifactId>jsinterop-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/dialogs/PromptDialogBox.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/dialogs/PromptDialogBox.java
@@ -221,15 +221,19 @@ public class PromptDialogBox extends DialogBox {
   }
 
   protected void onOk() {
-    if ( validatorCallback == null || ( validatorCallback != null && validatorCallback.validate() ) ) {
-      try {
-        if ( callback != null ) {
-          callback.okPressed();
-        }
-      } catch ( Throwable dontCare ) {
-        //ignore
-      }
+    if ( validatorCallback == null || validatorCallback.validate() ) {
+      onOkValid();
       hide();
+    }
+  }
+
+  protected void onOkValid() {
+    try {
+      if ( callback != null ) {
+        callback.okPressed();
+      }
+    } catch ( Throwable dontCare ) {
+      //ignore
     }
   }
 

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFile.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFile.java
@@ -1,0 +1,160 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.gwt.widgets.client.genericfile;
+
+import org.pentaho.gwt.widgets.client.utils.string.StringUtils;
+
+import java.util.Date;
+
+public class GenericFile {
+  public static final String TYPE_FOLDER = "folder";
+  public static final String TYPE_FILE = "file";
+
+  private String name;
+  private String title;
+  private String description;
+  private String path;
+  private String parentPath;
+  private String provider;
+  private Date modifiedDate;
+  private boolean canAddChildren;
+
+  /**
+   * The type of file node. One of <code>file</code>, <code>folder</code>.
+   */
+  private String type;
+  private boolean hidden;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName( String name ) {
+    this.name = name;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle( String title ) {
+    this.title = title;
+  }
+
+  public String getTitleOrName() {
+    return StringUtils.isEmpty( title ) ? name : title;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription( String description ) {
+    this.description = description;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath( String path ) {
+    this.path = path;
+  }
+
+  public String getParentPath() {
+    return parentPath;
+  }
+
+  public void setParentPath( String parentPath ) {
+    this.parentPath = parentPath;
+  }
+
+  /**
+   * Indicates if the file is a group folder.
+   * <p>
+   * Group folders have no {@link #getPath() path} and serve only logical/presentational
+   * grouping purposes.
+   *
+   * @return <code>true</code>, if the file is a group folder;
+   * <code>false</code>, otherwise.
+   */
+  public boolean isGroupFolder() {
+    return path == null;
+  }
+
+  /**
+   * Indicates if the file is a provider root folder.
+   * <p>
+   * Provider root folders have a {@link #getPath() path}, such as <code>/</code>,
+   * yet have no {@link #getParentPath() parent path}.
+   *
+   * @return <code>true</code>, if the file is a file system root;
+   * <code>false</code>, otherwise.
+   */
+  public boolean isProviderRootFolder() {
+    return path != null && parentPath == null;
+  }
+
+  public String getProvider() {
+    return provider;
+  }
+
+  public void setProvider( String provider ) {
+    this.provider = provider;
+  }
+
+  public Date getModifiedDate() {
+    return modifiedDate;
+  }
+
+  public void setModifiedDate( Date modifiedDate ) {
+    this.modifiedDate = modifiedDate;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType( String type ) {
+    this.type = type;
+  }
+
+  public boolean isFolder() {
+    return TYPE_FOLDER.equals( this.type );
+  }
+
+  public boolean isFile() {
+    return TYPE_FILE.equals( this.type );
+  }
+
+  public boolean isHidden() {
+    return hidden;
+  }
+
+  public void setHidden( boolean hidden ) {
+    this.hidden = hidden;
+  }
+
+  public boolean isCanAddChildren() {
+    return canAddChildren;
+  }
+
+  public void setCanAddChildren( boolean canAddChildren ) {
+    this.canAddChildren = canAddChildren;
+  }
+}

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileNameUtils.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileNameUtils.java
@@ -1,0 +1,94 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ */
+package org.pentaho.gwt.widgets.client.genericfile;
+
+import com.google.gwt.regexp.shared.MatchResult;
+import com.google.gwt.regexp.shared.RegExp;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import org.pentaho.gwt.widgets.client.utils.NameUtils;
+import org.pentaho.gwt.widgets.client.utils.string.StringTokenizer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GenericFileNameUtils {
+  public static final String PATH_SEPARATOR = "/";
+
+  private static final RegExp pathWithProtocolPattern = RegExp.compile( "^(\\w+://)(.*)$" );
+
+  private GenericFileNameUtils() {
+  }
+
+  // TODO: For repo, NameUtils.encodeRepositoryPath, ~ is converted to \t...
+  // Here, theres pvfs:// prefixes in play as well...
+  // See Common-UI's Encoder.encodeRepositoryPath.
+  @NonNull
+  public static String encodePath( @NonNull String path ) {
+    return path
+      .replace( ":", "~" )
+      .replace( PATH_SEPARATOR, ":" );
+  }
+
+  @NonNull
+  public static String buildPath( @NonNull String basePath, @NonNull String relativePath ) {
+    return basePath + PATH_SEPARATOR + relativePath;
+  }
+
+  public static boolean isValidFolderName( @Nullable String name ) {
+    return NameUtils.isValidFolderName( name );
+  }
+
+  @NonNull
+  public static List<String> splitPath( @Nullable String path ) {
+    List<String> segments = new ArrayList<>();
+
+    if ( path != null ) {
+      String normalizedPath = path;
+
+      // Extract the root of the path and add as first segment.
+      if ( path.startsWith( PATH_SEPARATOR ) ) {
+        segments.add( PATH_SEPARATOR );
+        normalizedPath = normalizedPath.substring( 1 );
+      } else {
+        MatchResult match = pathWithProtocolPattern.exec( normalizedPath );
+        if ( match != null ) {
+          segments.add( match.getGroup( 1 ) );
+          normalizedPath = match.getGroup( 2 );
+        }
+      }
+
+      // Tokenizer already strips a hanging /.
+      StringTokenizer st = new StringTokenizer( normalizedPath, PATH_SEPARATOR );
+      for ( int i = 0; i < st.countTokens(); i++ ) {
+        String token = st.tokenAt( i );
+        segments.add( token );
+      }
+    }
+
+    return segments;
+  }
+
+  @NonNull
+  public static String getParentPath( @NonNull String path ) {
+    if ( path.endsWith( PATH_SEPARATOR ) ) {
+      path = path.substring( 0, path.length() - 1 );
+    }
+
+    return path.substring( 0, path.lastIndexOf( PATH_SEPARATOR ) );
+  }
+}

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileTree.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileTree.java
@@ -1,0 +1,61 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.gwt.widgets.client.genericfile;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GenericFileTree {
+
+  private GenericFile file;
+
+  private List<GenericFileTree> children = new ArrayList<>();
+
+  public GenericFileTree() {
+  }
+
+  public GenericFileTree( GenericFile file ) {
+    this.file = file;
+  }
+
+  public GenericFile getFile() {
+    return file;
+  }
+
+  public void setFile( GenericFile file ) {
+    this.file = file;
+  }
+
+  public List<GenericFileTree> getChildren() {
+    return children;
+  }
+
+  public void setChildren( List<GenericFileTree> children ) {
+    this.children = children;
+  }
+
+  public void addChild( GenericFileTree tree ) {
+    children.add( tree );
+  }
+
+  public boolean hasChildFolders() {
+    return children != null && children.stream().anyMatch( child -> child.getFile().isFolder() );
+  }
+}

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileTreeComparator.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileTreeComparator.java
@@ -1,0 +1,58 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ */
+package org.pentaho.gwt.widgets.client.genericfile;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import java.util.Comparator;
+
+public class GenericFileTreeComparator implements Comparator<GenericFileTree> {
+
+  private boolean useTitle = true;
+
+  public GenericFileTreeComparator() {
+  }
+
+  public GenericFileTreeComparator( boolean useTitle ) {
+    this.useTitle = useTitle;
+  }
+
+  @Override
+  public int compare( GenericFileTree fileTree1, GenericFileTree fileTree2 ) {
+    return compare( getSortName( fileTree1 ), getSortName( fileTree2 ) );
+  }
+
+  @NonNull
+  private String getSortName( @NonNull GenericFileTree fileTree ) {
+    GenericFile file = fileTree.getFile();
+    String sortName = useTitle ? file.getTitleOrName() : file.getName();
+    return sortName == null ? "" : sortName;
+  }
+
+  private native int compare( @NonNull String a, @NonNull String b ) /*-{
+    var aName = a.toLowerCase();
+    var bName = b.toLowerCase();
+    if(aName.localeCompare(bName) === 0) {
+      // If values equalsIgnoreCase, use original values for comparison
+      aName = a;
+      bName = b;
+      return (aName < bName) ? -1 : ((aName > bName) ? 1 : 0);
+    }
+
+    return aName.localeCompare(bName);
+  }-*/;
+}

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileTreeJsonParser.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileTreeJsonParser.java
@@ -1,0 +1,138 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.gwt.widgets.client.genericfile;
+
+import com.google.gwt.json.client.JSONArray;
+import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONParser;
+import com.google.gwt.json.client.JSONValue;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * Parses a JSON string into a {@link GenericFileTree} object.
+ */
+public class GenericFileTreeJsonParser {
+  @NonNull
+  private final String jsonText;
+
+  public GenericFileTreeJsonParser( @NonNull String jsonText ) {
+    Objects.requireNonNull( jsonText );
+    this.jsonText = jsonText;
+  }
+
+  /**
+   * Parses the file tree JSON and returns the corresponding file tree object.
+   *
+   * @return The file tree object.
+   */
+  @NonNull
+  public GenericFileTree getTree() {
+    JSONObject jsonFileTree = JSONParser.parseStrict( jsonText ).isObject();
+    return parseFileTree( jsonFileTree );
+  }
+
+  @NonNull
+  private static GenericFileTree parseFileTree( @NonNull JSONObject jsonFileTree ) {
+
+    GenericFile file = parseFile( getFieldValueAsJSONObject( jsonFileTree, "file" ) );
+
+    GenericFileTree fileTree = new GenericFileTree( file );
+
+    JSONArray jsonChildren = getFieldValueAsJSONArray( jsonFileTree, "children" );
+    if ( jsonChildren != null ) {
+      for ( int i = 0; i < jsonChildren.size(); i++ ) {
+        fileTree.addChild( parseFileTree( jsonChildren.get( i ).isObject() ) );
+      }
+    }
+
+    return fileTree;
+  }
+
+  @NonNull
+  private static GenericFile parseFile( @NonNull JSONObject jsonFile ) {
+
+    GenericFile file = new GenericFile();
+
+    // TODO: check this is needed.
+    // There are times the web service wraps the json RepositoryFile with `file` and times when it does not.
+    // The following line mitigates this, so it doesn't care what form it is getting.
+    JSONObject fileJSON = jsonFile.get( "file" ) != null ? jsonFile.get( "file" ).isObject() : jsonFile;
+
+    file.setProvider( getFieldValueAsString( fileJSON, "provider" ) );
+    file.setName( getFieldValueAsString( fileJSON, "name" ) );
+    file.setTitle( getFieldValueAsString( fileJSON, "title" ) );
+    file.setDescription( getFieldValueAsString( fileJSON, "description" ) );
+    file.setPath( getFieldValueAsString( fileJSON, "path" ) );
+    file.setParentPath( getFieldValueAsString( fileJSON, "parent" ) );
+    file.setType( getFieldValueAsString( fileJSON, "type" ) );
+    file.setModifiedDate( getFieldValueAsDate( fileJSON, "modifiedDate" ) );
+    file.setHidden( getFieldValueAsBoolean( fileJSON, "hidden", false ) );
+
+    if ( file.isFolder() ) {
+      file.setCanAddChildren( getFieldValueAsBoolean( fileJSON, "canAddChildren", false ) );
+    }
+
+    return file;
+  }
+
+  @Nullable
+  private static JSONObject getFieldValueAsJSONObject( @NonNull JSONObject jso, @NonNull String fieldName ) {
+    JSONValue jsonValue = jso.get( fieldName );
+    return jsonValue != null ? jsonValue.isObject() : null;
+  }
+
+  @Nullable
+  private static JSONArray getFieldValueAsJSONArray( @NonNull JSONObject jsonFileTree, @NonNull String fieldName ) {
+    JSONValue jsonValue = jsonFileTree.get( fieldName );
+    return jsonValue != null ? jsonValue.isArray() : null;
+  }
+
+  @Nullable
+  private static String getFieldValueAsString( @NonNull JSONObject jso, @NonNull String fieldName ) {
+    JSONValue jsonValue = jso.get( fieldName );
+    return jsonValue != null && jsonValue.isString() != null
+      ? jsonValue.isString().stringValue()
+      : null;
+  }
+
+  @Nullable
+  private static Long getFieldValueAsLong( @NonNull JSONObject jso, @NonNull String fieldName ) {
+    JSONValue jsonValue = jso.get( fieldName );
+    return jsonValue != null && jsonValue.isNumber() != null
+      ? (long) jsonValue.isNumber().doubleValue()
+      : null;
+  }
+
+  @Nullable
+  private static Date getFieldValueAsDate( @NonNull JSONObject jso, @NonNull String fieldName ) {
+    Long value = getFieldValueAsLong( jso, fieldName );
+    return value != null ? new Date( value ) : null;
+  }
+
+  private static boolean getFieldValueAsBoolean( @NonNull JSONObject jso, @NonNull String fieldName,
+                                                 boolean defaultValue ) {
+    JSONValue jsonValue = jso.get( fieldName );
+    return jsonValue != null && jsonValue.isBoolean() != null
+      ? jsonValue.isBoolean().booleanValue()
+      : defaultValue;
+  }
+}

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/LeafItemWidget.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/LeafItemWidget.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2021 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara. All rights reserved.
  */
 
 package org.pentaho.mantle.client.dialogs.folderchooser;
@@ -24,8 +24,7 @@ import com.google.gwt.user.client.ui.Label;
 import org.pentaho.mantle.client.environment.EnvironmentHelper;
 
 /**
- * @author wseyler
- * 
+ * Used on leaf folder nodes, so that these do not show the expand/collapse arrow icon.
  */
 public class LeafItemWidget extends Composite {
   Image leafImage;
@@ -35,7 +34,8 @@ public class LeafItemWidget extends Composite {
     HorizontalPanel widget = new HorizontalPanel();
     initWidget( widget );
 
-    leafImage = new Image( EnvironmentHelper.getFullyQualifiedURL() + "content/common-ui/resources/themes/images/spacer.gif" ); //ImageUtil.getThemeableImage( styleName );
+    leafImage =
+      new Image( EnvironmentHelper.getFullyQualifiedURL() + "content/common-ui/resources/themes/images/spacer.gif" );
     for ( String style : styleName ) {
       leafImage.addStyleName( style );
     }

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/RefreshFolderTreeCommand.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/RefreshFolderTreeCommand.java
@@ -1,0 +1,94 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.mantle.client.dialogs.folderchooser;
+
+import com.google.gwt.http.client.Request;
+import com.google.gwt.http.client.RequestBuilder;
+import com.google.gwt.http.client.RequestCallback;
+import com.google.gwt.http.client.RequestException;
+import com.google.gwt.http.client.Response;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import org.pentaho.gwt.widgets.client.dialogs.MessageDialogBox;
+import org.pentaho.gwt.widgets.client.ui.ICallback;
+import org.pentaho.mantle.client.commands.AbstractCommand;
+import org.pentaho.mantle.client.messages.Messages;
+
+import static org.pentaho.mantle.client.environment.EnvironmentHelper.getFullyQualifiedURL;
+
+public class RefreshFolderTreeCommand extends AbstractCommand {
+  @Nullable
+  private ICallback<Void> callback;
+
+  @Nullable
+  public ICallback<Void> getCallback() {
+    return callback;
+  }
+
+  public void setCallback( @Nullable ICallback<Void> callback ) {
+    this.callback = callback;
+  }
+
+  @Override
+  protected void performOperation() {
+    performOperation( true );
+  }
+
+  @Override
+  protected void performOperation( boolean feedback ) {
+    try {
+      RequestBuilder requestBuilder = new RequestBuilder( RequestBuilder.DELETE, buildClearCacheUrl() );
+      requestBuilder.sendRequest( null, new RequestCallback() {
+        public void onError( Request request, Throwable caught ) {
+          showRefreshFolderTreeResponseError();
+        }
+
+        public void onResponseReceived( Request request, Response response ) {
+          if ( response.getStatusCode() == Response.SC_NO_CONTENT ) {
+            onFolderTreeRefreshed();
+          } else {
+            showRefreshFolderTreeResponseError();
+          }
+        }
+      } );
+    } catch ( RequestException e ) {
+      showRefreshFolderTreeResponseError();
+    }
+  }
+
+  @NonNull
+  private static String buildClearCacheUrl() {
+    return getFullyQualifiedURL() + "plugin/scheduler-plugin/api/generic-files/folders/tree/cache";
+  }
+
+  private void onFolderTreeRefreshed() {
+    if ( callback != null ) {
+      callback.onHandle( null );
+    }
+  }
+
+  private void showRefreshFolderTreeResponseError() {
+    showErrorDialog( Messages.getString( "couldNotRefreshFolderTree" ) );
+  }
+
+  private static void showErrorDialog( String errorMessage ) {
+    MessageDialogBox dialogBox =
+      new MessageDialogBox( Messages.getString( "error" ), errorMessage, false, false, true );
+    dialogBox.center();
+  }
+}

--- a/widgets/src/main/resources/org/pentaho/mantle/public/messages/mantleMessages.properties
+++ b/widgets/src/main/resources/org/pentaho/mantle/public/messages/mantleMessages.properties
@@ -226,6 +226,7 @@ newFolderColon=New Folder:
 couldNotWriteToFolder=Cannot Write To Folder
 couldNotCreateFolderDuplicate=Folder &#39;{0}&#39; already exists.
 couldNotCreateFolder=You do not have permission to create this folder. Contact your administrator for assistance.
+couldNotRefreshFolderTree=It was not possible to refresh the folders.
 containsIllegalCharacters=Folder name contains illegal characters
 allPermissions=All Permissions
 create=Create

--- a/widgets/src/main/resources/org/pentaho/mantle/public/messages/mantleMessages_en.properties
+++ b/widgets/src/main/resources/org/pentaho/mantle/public/messages/mantleMessages_en.properties
@@ -225,6 +225,7 @@ newFolderColon=New Folder:
 couldNotWriteToFolder=Cannot Write To Folder
 couldNotCreateFolderDuplicate=Folder &#39;{0}&#39; already exists.
 couldNotCreateFolder=You do not have permission to create this folder. Contact your administrator for assistance.
+couldNotRefreshFolderTree=It was not possible to refresh the folders.
 containsIllegalCharacters=Folder name contains illegal characters
 allPermissions=All Permissions
 create=Create

--- a/widgets/src/test/java/org/pentaho/mantle/client/dialogs/folderchooser/FolderTreeTest.java
+++ b/widgets/src/test/java/org/pentaho/mantle/client/dialogs/folderchooser/FolderTreeTest.java
@@ -21,7 +21,7 @@ import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -40,6 +40,6 @@ public class FolderTreeTest {
     tree.select( path );
 
     verify( tree ).select( path );
-    verify( tree ).getTreeItem( any() );
+    verify( tree ).findTreeItem( anyString() );
   }
 }


### PR DESCRIPTION
Part of PR set: https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/68

Updated Folder Chooser dialog to consuming the new Generic File endpoint, instead of the Repository endpoint:
- Added refresh button to the toolbar
- Refactored, simplified code

Additionally, changed integration with the Scheduler dialogs, regarding output location path validation.

Co-authored by: @rmansoor and me (also added to commit message as described in [github docs](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors)).

@pentaho/hoth, @pentaho/r2d2, @pentaho/millenniumfalcon, please review at your will.