### PR TITLE
[BACKLOG-37877] Add method GenericFileNameUtils.isRepositoryPath

### DIFF
--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileNameUtils.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileNameUtils.java
@@ -44,6 +44,10 @@ public class GenericFileNameUtils {
       .replace( PATH_SEPARATOR, ":" );
   }
 
+  public static boolean isRepositoryPath( @NonNull String path ) {
+    return path.startsWith( PATH_SEPARATOR );
+  }
+
   @NonNull
   public static String buildPath( @NonNull String basePath, @NonNull String relativePath ) {
     return basePath + PATH_SEPARATOR + relativePath;


### PR DESCRIPTION
- Centralizes knowledge of how to distinguish between repository paths and others. Needed by `SchedulerPanel`, scheduler perspective.

Part of PR set: https://github.com/pentaho/pentaho-scheduler-plugin/pull/59.

@pentaho/hoth, please, review.