### PR TITLE
[BACKLOG-39945] Dashboards - Unable to get the dropdown of prompts to…

### DIFF
--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/listbox/CustomListBox.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/listbox/CustomListBox.java
@@ -12,28 +12,13 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2023 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  */
 
 package org.pentaho.gwt.widgets.client.listbox;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import com.google.gwt.event.dom.client.KeyCodes;
-import com.google.gwt.user.client.ui.Focusable;
-import org.pentaho.gwt.widgets.client.panel.PentahoFocusPanel;
-import org.pentaho.gwt.widgets.client.panel.HorizontalFlexPanel;
-import org.pentaho.gwt.widgets.client.panel.ScrollFlexPanel;
-import org.pentaho.gwt.widgets.client.panel.VerticalFlexPanel;
-import org.pentaho.gwt.widgets.client.text.SearchTextBox;
-import org.pentaho.gwt.widgets.client.utils.ElementUtils;
-import org.pentaho.gwt.widgets.client.utils.Rectangle;
-import org.pentaho.gwt.widgets.client.utils.string.StringUtils;
-
 import com.allen_sauer.gwt.dnd.client.DragController;
+import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Element;
@@ -43,6 +28,7 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.ChangeListener;
 import com.google.gwt.user.client.ui.FlexTable;
 import com.google.gwt.user.client.ui.FocusListener;
+import com.google.gwt.user.client.ui.Focusable;
 import com.google.gwt.user.client.ui.KeyboardListener;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.MouseListener;
@@ -53,9 +39,21 @@ import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
+import org.pentaho.gwt.widgets.client.panel.HorizontalFlexPanel;
+import org.pentaho.gwt.widgets.client.panel.PentahoFocusPanel;
+import org.pentaho.gwt.widgets.client.panel.ScrollFlexPanel;
+import org.pentaho.gwt.widgets.client.panel.VerticalFlexPanel;
+import org.pentaho.gwt.widgets.client.text.SearchTextBox;
+import org.pentaho.gwt.widgets.client.utils.ElementUtils;
+import org.pentaho.gwt.widgets.client.utils.Rectangle;
+import org.pentaho.gwt.widgets.client.utils.string.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
- * 
  * ComplexListBox is a List-style widget can contain custom list-items made (images + text, text + checkboxes) This list
  * is displayed as a drop-down style component by default. If the visibleRowCount property is set higher than 1
  * (default), the list is rendered as a multi-line list box.
@@ -100,7 +98,6 @@ public class CustomListBox extends VerticalFlexPanel implements ChangeListener, 
 
   // Members for drop-down style
   protected FlexTable dropGrid = new FlexTable();
-  protected boolean popupShowing = false;
   private DropPopupPanel popup;
   private SearchTextBox searchTextBox = new SearchTextBox();
   private PopupList popupVbox = new PopupList();
@@ -682,9 +679,8 @@ public class CustomListBox extends VerticalFlexPanel implements ChangeListener, 
    * Used internally to hide/show drop-down popup.
    */
   protected void togglePopup() {
-    if ( !popupShowing ) {
+    if ( !isPopupShowing() ) {
       showPopup();
-      popupShowing = true;
     } else {
       popup.hide();
     }
@@ -1040,7 +1036,6 @@ public class CustomListBox extends VerticalFlexPanel implements ChangeListener, 
 
   public void onPopupClosed( PopupPanel popupPanel, boolean b ) {
     this.getSearchTextBox().clearText();
-    this.popupShowing = false;
   }
 
   public void onMouseDown( Widget widget, int i, int i1 ) {
@@ -1088,13 +1083,25 @@ public class CustomListBox extends VerticalFlexPanel implements ChangeListener, 
         break;
       case KeyCodes.KEY_TAB:
       case KeyCodes.KEY_ESCAPE:
-        if( popupShowing ){
+        if ( isPopupShowing() ) {
           popup.hide();
         }
         break;
       default:
         break;
     }
+  }
+
+  /**
+   * Indicates if the popup is created and showing.
+   * <p>
+   * Guards against the lazy creation of the drop-down's popup, and, otherwise,
+   * calls its {@link PopupPanel#isShowing()} method.
+   *
+   * @return {@code true} if the popup is open; {@code false}, otherwise.
+   */
+  protected boolean isPopupShowing() {
+    return popup != null && popup.isShowing();
   }
 
   public void onKeyPress( Widget widget, char c, int i ) {
@@ -1244,7 +1251,7 @@ public class CustomListBox extends VerticalFlexPanel implements ChangeListener, 
     }
 
     // Drop-down mode
-    if ( visible == 1 && popupShowing ) {
+    if ( visible == 1 && isPopupShowing() ) {
       togglePopup();
     }
 

--- a/widgets/src/test/java/org/pentaho/gwt/widgets/client/listbox/CustomListBoxTest.java
+++ b/widgets/src/test/java/org/pentaho/gwt/widgets/client/listbox/CustomListBoxTest.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2023 Hitachi Vantara. All rights reserved.
+* Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
 */
 
 package org.pentaho.gwt.widgets.client.listbox;
@@ -43,7 +43,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
@@ -558,6 +557,8 @@ public class CustomListBoxTest {
     final ListItem listItem = mock( ListItem.class );
     final Event event = mock( Event.class );
 
+    when( customListBox.isPopupShowing() ).thenReturn( true );
+
     customListBox.multiSelect = true;
     customListBox.itemSelected( listItem, event );
     verify( customListBox ).setFocus( true );
@@ -567,7 +568,6 @@ public class CustomListBoxTest {
 
     customListBox.multiSelect = false;
     customListBox.visible = 1;
-    customListBox.popupShowing = true;
     customListBox.itemSelected( listItem, event );
     verify( customListBox, times( 2 ) ).setFocus( true );
     verify( customListBox ).handleSelection( listItem, event );
@@ -668,13 +668,11 @@ public class CustomListBoxTest {
   @Test
   public void testOnPopupClosed() {
     doCallRealMethod().when( customListBox ).onPopupClosed( any(), anyBoolean() );
-    customListBox.popupShowing = true;
 
     boolean booleanValue = true; // it does nothing inside "onPopupClosed" method
     customListBox.onPopupClosed( mock( PopupPanel.class ), booleanValue );
 
     verify( customListBox.getSearchTextBox(), times( 1 ) ).clearText();
-    assertFalse( customListBox.popupShowing );
   }
 
   @Test


### PR DESCRIPTION
… assigning Sources to Parameters

The previous version of this code needlessly had a local variable to store whether the popup was showing or not. The only advantage was that it allowed to test for the popup to be opened without having to know if the popup had already been created. However, it was redundantly implementing logic already present in the PopupPanel class.

The code failed to keep the local state in sync with the popup's actual state, in the case where the dialog was closed during the process of showing it (via `togglePopup()`), due to being detected the anchor component was off view.

Cherry picked from: https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1023.
/cc @pentaho/hoth

Related PR for 10.1: https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1025