### PR TITLE
[BACKLOG-39254] Lazy loading for Select Folder dialog

### DIFF
--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileTree.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileTree.java
@@ -18,41 +18,52 @@
 package org.pentaho.gwt.widgets.client.genericfile;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class GenericFileTree {
 
-  private GenericFile file;
+  @NonNull
+  private final GenericFile file;
 
-  private List<GenericFileTree> children = new ArrayList<>();
+  @Nullable
+  private List<GenericFileTree> children;
 
-  public GenericFileTree() {
+  public GenericFileTree( @NonNull GenericFile file ) {
+    this.file = Objects.requireNonNull( file );
   }
 
-  public GenericFileTree( GenericFile file ) {
-    this.file = file;
-  }
-
+  @NonNull
   public GenericFile getFile() {
     return file;
   }
 
-  public void setFile( GenericFile file ) {
-    this.file = file;
-  }
-
+  @Nullable
   public List<GenericFileTree> getChildren() {
     return children;
   }
 
-  public void setChildren( List<GenericFileTree> children ) {
+  public void setChildren( @Nullable List<GenericFileTree> children ) {
     this.children = children;
   }
 
-  public void addChild( GenericFileTree tree ) {
+  public void addChild( @NonNull GenericFileTree tree ) {
+    if ( children == null ) {
+      children = new ArrayList<>();
+    }
+
     children.add( tree );
+  }
+
+  public boolean areChildrenLoaded() {
+    return children != null;
+  }
+
+  public boolean hasChildren() {
+    return children != null && !children.isEmpty();
   }
 
   public boolean hasChildFolders() {

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileTreeJsonParser.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileTreeJsonParser.java
@@ -24,6 +24,7 @@ import com.google.gwt.json.client.JSONValue;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.Objects;
 
@@ -59,6 +60,9 @@ public class GenericFileTreeJsonParser {
 
     JSONArray jsonChildren = getFieldValueAsJSONArray( jsonFileTree, "children" );
     if ( jsonChildren != null ) {
+      // Make sure that an empty list is reflected.
+      fileTree.setChildren( new ArrayList<>() );
+
       for ( int i = 0; i < jsonChildren.size(); i++ ) {
         fileTree.addChild( parseFileTree( jsonChildren.get( i ).isObject() ) );
       }
@@ -82,7 +86,7 @@ public class GenericFileTreeJsonParser {
     file.setTitle( getFieldValueAsString( fileJSON, "title" ) );
     file.setDescription( getFieldValueAsString( fileJSON, "description" ) );
     file.setPath( getFieldValueAsString( fileJSON, "path" ) );
-    file.setParentPath( getFieldValueAsString( fileJSON, "parent" ) );
+    file.setParentPath( getFieldValueAsString( fileJSON, "parentPath" ) );
     file.setType( getFieldValueAsString( fileJSON, "type" ) );
     file.setModifiedDate( getFieldValueAsDate( fileJSON, "modifiedDate" ) );
     file.setHidden( getFieldValueAsBoolean( fileJSON, "hidden", false ) );

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/FolderTreeItem.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/FolderTreeItem.java
@@ -29,6 +29,11 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 
 public class FolderTreeItem extends TreeItem {
+
+  private static final String LOADING_STYLE_NAME = "loading";
+
+  private boolean isLoading;
+
   public FolderTreeItem() {
   }
 
@@ -82,6 +87,23 @@ public class FolderTreeItem extends TreeItem {
     return new FolderTreeItemIterable( this );
   }
 
+  public boolean isLoading() {
+    return isLoading;
+  }
+
+  public void setLoading( boolean loading ) {
+    if ( this.isLoading != loading ) {
+
+      this.isLoading = loading;
+
+      if ( this.isLoading ) {
+        addStyleName( LOADING_STYLE_NAME );
+      } else {
+        removeStyleName( LOADING_STYLE_NAME );
+      }
+    }
+  }
+
   private static class FolderTreeItemIterable implements Iterable<FolderTreeItem> {
     @NonNull
     private final TreeItem parentTreeItem;
@@ -91,7 +113,8 @@ public class FolderTreeItem extends TreeItem {
       this.parentTreeItem = parentTreeItem;
     }
 
-    @Override @NonNull
+    @Override
+    @NonNull
     public Iterator<FolderTreeItem> iterator() {
       return new FolderTreeItemIterator();
     }

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/SelectFolderDialog.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/SelectFolderDialog.java
@@ -20,7 +20,6 @@ package org.pentaho.mantle.client.dialogs.folderchooser;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.ui.Image;
-import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -74,6 +73,7 @@ public class SelectFolderDialog extends PromptDialogBox {
     setWidthCategory( DialogWidthCategory.SMALL );
 
     tree = new MySolutionTree();
+    tree.setDepth( 1 );
     tree.addSelectionHandler( event -> onSelectionChanged( tree.getSelectedFileModel() ) );
 
     SimplePanel treeWrapper = new SimplePanel( tree );
@@ -125,12 +125,10 @@ public class SelectFolderDialog extends PromptDialogBox {
     button.setToolTip( Messages.getString( "refreshTooltip" ) );
 
     button.setCommand( () -> {
-      GenericFile selectedFileModel = tree.getSelectedFileModel();
-      if ( selectedFileModel != null ) {
-        RefreshFolderTreeCommand refreshFolderCommand = new RefreshFolderTreeCommand();
-        refreshFolderCommand.setCallback( nothing -> fetchModel( null ) );
-        refreshFolderCommand.execute();
-      }
+      // Refresh command applies regardless of selection.
+      RefreshFolderTreeCommand refreshFolderCommand = new RefreshFolderTreeCommand();
+      refreshFolderCommand.setCallback( nothing -> fetchModel( null ) );
+      refreshFolderCommand.execute();
     } );
 
     return button;
@@ -161,7 +159,7 @@ public class SelectFolderDialog extends PromptDialogBox {
   }
 
   private void fetchModel( String selectedPath ) {
-    tree.fetchModel( null, selectedPath );
+    tree.fetchTreeModel( null, selectedPath );
   }
 
   @Override

--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/crystal/globalCrystal.css
@@ -5660,6 +5660,11 @@ treecontrol.tree-classic li .tree-selected {
   background-color: white;
 }
 
+/* Make sure an item which no longer has children does not show the arrow image. */
+.select-folder-tree .leaf-widget:not(.parent-widget) > table > tbody > tr > td > img {
+  display: none;
+}
+
 #sidepanel #sidepaneltabset > div > span{
   overflow: hidden;
   text-overflow: ellipsis;

--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/ruby/globalRuby.css
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/ruby/globalRuby.css
@@ -8428,6 +8428,11 @@ treecontrol.tree-classic li .tree-selected {
   background-size: contain !important;
 }
 
+/* Make sure an item which no longer has children does not show the arrow image. */
+.select-folder-tree .leaf-widget:not(.parent-widget) > table > tbody > tr > td > img {
+  display: none;
+}
+
 #sidepanel #sidepaneltabset > div > span {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/themes/public/themes/sapphire/globalSapphire.css
@@ -7010,6 +7010,11 @@ treecontrol.tree-classic li .tree-selected {
   background-color: white;
 }
 
+/* Make sure an item which no longer has children does not show the arrow image. */
+.select-folder-tree .leaf-widget:not(.parent-widget) > table > tbody > tr > td > img {
+  display: none;
+}
+
 #sidepanel #sidepaneltabset > div > span {
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
Issue: https://hv-eng.atlassian.net/browse/BACKLOG-39254

Part of PR set: https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/184

- Changed `GenericFileTreeJSONParser` to account for the name change from `parent` to `parentPath`, to match change in REST service
- Made changes to account for that `GenericFileTree#getChildren()` can now be `null` to mean children are not loaded yet
- Changed `SelectFolderDialog` to use a max depth of 1 to get folders
- Made some CSS style changes that account for folders which remain empty after having been lazily-loaded

@pentaho/hoth, please review. Keeping in draft for now, while I finish writing the unit tests.