### PR TITLE
[BACKLOG-40489] Error when accessing browse files with a user with sp…

### DIFF
--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileNameUtils.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileNameUtils.java
@@ -34,15 +34,11 @@ public class GenericFileNameUtils {
   private GenericFileNameUtils() {
   }
 
-  // TODO: For repo, NameUtils.encodeRepositoryPath, ~ is converted to \t...
-  // Here, theres pvfs:// prefixes in play as well...
-  // See Common-UI's Encoder.encodeRepositoryPath.
   @NonNull
-  public static String encodePath( @NonNull String path ) {
-    return path
-      .replace( ":", "~" )
-      .replace( PATH_SEPARATOR, ":" );
-  }
+  public static native String encodePath( @NonNull String path )
+  /*-{
+    return $wnd.pho.Encoder.encodeGenericFilePath(path);
+  }-*/;
 
   public static boolean isRepositoryPath( @NonNull String path ) {
     return path.startsWith( PATH_SEPARATOR );


### PR DESCRIPTION
…ecial characteres (that used to work before)

- Use new Encoder encode function for generic file paths to address handling of "~" in file paths


Related PRs (including this one), to be merged together:
1. https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1762
2. https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1032
3. https://github.com/pentaho/pentaho-scheduler-plugin/pull/164
4. https://github.com/pentaho/pentaho-platform/pull/5583