### PR TITLE
[BACKLOG-40475] Browse Perspective: "Open" PVFS file actions

### DIFF
--- a/widgets/pom.xml
+++ b/widgets/pom.xml
@@ -62,6 +62,7 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
+      <scope>compile</scope>
     </dependency>
 
     <!-- Test -->


### PR DESCRIPTION
PR Set:
1. https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1039
2. https://github.com/pentaho/pentaho-platform/pull/5616
3. https://github.com/pentaho/pentaho-scheduler-plugin/pull/178
4. https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/243

- added `compile` scope to spotbugs dependency to allow us to use GenericFilenameUtils in pentaho-platform, including GWT Super Dev Mode