### PR TITLE
[BACKLOG-41091] Use Decoded File Name and Title Values in Scheduler Perspective + Browse Perspective missed case

### DIFF
--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFile.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFile.java
@@ -26,6 +26,7 @@ public class GenericFile {
   public static final String TYPE_FILE = "file";
 
   private String name;
+  private String nameDecoded;
   private String title;
   private String description;
   private String path;
@@ -48,6 +49,14 @@ public class GenericFile {
     this.name = name;
   }
 
+  public String getNameDecoded() {
+    return StringUtils.isEmpty( nameDecoded ) ? name : nameDecoded;
+  }
+
+  public void setNameDecoded( String nameDecoded ) {
+    this.nameDecoded = nameDecoded;
+  }
+
   public String getTitle() {
     return title;
   }
@@ -56,8 +65,8 @@ public class GenericFile {
     this.title = title;
   }
 
-  public String getTitleOrName() {
-    return StringUtils.isEmpty( title ) ? name : title;
+  public String getTitleOrNameDecoded() {
+    return StringUtils.isEmpty( title ) ? getNameDecoded() : title;
   }
 
   public String getDescription() {

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileTreeComparator.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileTreeComparator.java
@@ -39,7 +39,7 @@ public class GenericFileTreeComparator implements Comparator<GenericFileTree> {
   @NonNull
   private String getSortName( @NonNull GenericFileTree fileTree ) {
     GenericFile file = fileTree.getFile();
-    String sortName = useTitle ? file.getTitleOrName() : file.getName();
+    String sortName = useTitle ? file.getTitleOrNameDecoded() : file.getNameDecoded();
     return sortName == null ? "" : sortName;
   }
 

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileTreeJsonParser.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileTreeJsonParser.java
@@ -83,6 +83,7 @@ public class GenericFileTreeJsonParser {
 
     file.setProvider( getFieldValueAsString( fileJSON, "provider" ) );
     file.setName( getFieldValueAsString( fileJSON, "name" ) );
+    file.setNameDecoded( getFieldValueAsString( fileJSON, "nameDecoded" ) );
     file.setTitle( getFieldValueAsString( fileJSON, "title" ) );
     file.setDescription( getFieldValueAsString( fileJSON, "description" ) );
     file.setPath( getFieldValueAsString( fileJSON, "path" ) );

--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/FolderTree.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/FolderTree.java
@@ -290,7 +290,7 @@ public class FolderTree extends Tree {
   private FolderTreeItem buildLoadingTreeItem() {
     GenericFileTree treeModel = getLoadingTreeModel();
 
-    FolderTreeItem loadingTreeItem = new FolderTreeItem( treeModel.getFile().getName() );
+    FolderTreeItem loadingTreeItem = new FolderTreeItem( treeModel.getFile().getTitleOrNameDecoded() );
     loadingTreeItem.setFileTreeModel( treeModel );
 
     return loadingTreeItem;
@@ -648,8 +648,8 @@ public class FolderTree extends Tree {
 
     assert !fileModel.isGroupFolder() : "Folder tree item should not be mapped to group folder";
 
-    String name = fileModel.getName();
-    String title = fileModel.getTitleOrName();
+    String name = fileModel.getNameDecoded();
+    String title = fileModel.getTitleOrNameDecoded();
     String description = fileModel.getDescription();
 
     FolderTreeItem treeItem = new FolderTreeItem();


### PR DESCRIPTION
Changed Select Folder dialog to use new IGenericFile#getNameDecoded() property

PR Set:
https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1042
https://github.com/pentaho/pentaho-platform/pull/5652
https://github.com/pentaho/pentaho-scheduler-plugin/pull/187
https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/256