### PR TITLE
[BACKLOG-41477] Edit schedule invalid fall back for PVFS output location

### DIFF
--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileNameUtils.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/genericfile/GenericFileNameUtils.java
@@ -93,6 +93,11 @@ public class GenericFileNameUtils {
       path = path.substring( 0, path.length() - 1 );
     }
 
-    return path.substring( 0, path.lastIndexOf( PATH_SEPARATOR ) );
+    int index = path.lastIndexOf( PATH_SEPARATOR );
+    if ( index < 0 ) {
+      return "";
+    }
+
+    return path.substring( 0, index );
   }
 }


### PR DESCRIPTION
Cherry-picked from: https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1043

/cc @pentaho/hoth