### PR TITLE
feat(select folder dialog): expand initially selected folder [BACKLOG-41878]

### DIFF
--- a/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/FolderTree.java
+++ b/widgets/src/main/java/org/pentaho/mantle/client/dialogs/folderchooser/FolderTree.java
@@ -373,7 +373,12 @@ public class FolderTree extends Tree {
     buildSolutionTree();
 
     if ( initialSelectedPath != null ) {
-      select( initialSelectedPath );
+      TreeItem selectedItem = select( initialSelectedPath );
+
+      // Expand selected item when loading root tree. Ignored if it has no children.
+      if ( selectedItem != null ) {
+        selectedItem.setState( true );
+      }
     } else {
       openRootTreeItems();
     }
@@ -498,14 +503,19 @@ public class FolderTree extends Tree {
     }
   }
 
-  public void select( @Nullable String path ) {
+  public TreeItem select( @Nullable String path ) {
     TreeItem newSelectedItem = findTreeItem( path );
     if ( newSelectedItem != null ) {
       setSelectedItem( newSelectedItem, true );
-    } else if ( path != null && !path.equals( getHomeFolder() ) ) {
-      // If the given path did not exist, then select the home folder (recursive call).
-      select( getHomeFolder() );
+      return newSelectedItem;
     }
+
+    if ( path != null && !path.equals( getHomeFolder() ) ) {
+      // If the given path did not exist, then select the home folder (recursive call).
+      return select( getHomeFolder() );
+    }
+
+    return null;
   }
 
   @Nullable


### PR DESCRIPTION
- The generic files endpoint now applies max depth to the expanded path parameter as well, and so the selected folder can be immediately expanded with no additional HTTP request needed.
- This restores pre-10 behavior and aligns with Pentaho App Shell UI behavior.

Depends on:
- https://github.com/pentaho/pentaho-scheduler-plugin/pull/216

Related with:
- https://github.com/pentaho/pentaho-platform/pull/5755

@pentaho/millenniumfalcon, please review.