### PR TITLE
[BACKLOG-42885]-Upgrading Jetty version from 11.0.14 to 12.0.15 to support Jakarta EE 10

### DIFF
--- a/widgets/pom.xml
+++ b/widgets/pom.xml
@@ -122,20 +122,20 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-webapp</artifactId>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-webapp</artifactId>
       <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-annotations</artifactId>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-annotations</artifactId>
       <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>apache-jsp</artifactId>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-apache-jsp</artifactId>
       <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
[BACKLOG-42885]-Upgrading Jetty version from 11.0.14 to 12.0.15 to support Jakarta EE 10

[BACKLOG-42885]: https://hv-eng.atlassian.net/browse/BACKLOG-42885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ