### PR TITLE
[BACKLOG-40823] - Upgrade the Tomcat version from current to 10.x.x with Java 17

### DIFF
--- a/assemblies/widgets/pom.xml
+++ b/assemblies/widgets/pom.xml
@@ -35,13 +35,13 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
       <classifier>sources</classifier>
       <scope>provided</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -92,14 +92,14 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>javax.validation</groupId>
-        <artifactId>validation-api</artifactId>
-        <version>1.0.0.GA</version>
+        <groupId>jakarta.validation</groupId>
+        <artifactId>jakarta.validation-api</artifactId>
+        <version>${jakarta.validation.version}</version>
       </dependency>
       <dependency>
-        <groupId>javax.validation</groupId>
-        <artifactId>validation-api</artifactId>
-        <version>1.0.0.GA</version>
+        <groupId>jakarta.validation</groupId>
+        <artifactId>jakarta.validation-api</artifactId>
+        <version>${jakarta.validation.version}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>

--- a/widgets/pom.xml
+++ b/widgets/pom.xml
@@ -79,13 +79,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
       <classifier>sources</classifier>
       <scope>test</scope>
     </dependency>

--- a/widgets/pom.xml
+++ b/widgets/pom.xml
@@ -122,20 +122,20 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-webapp</artifactId>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-webapp</artifactId>
       <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-annotations</artifactId>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-annotations</artifactId>
       <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>apache-jsp</artifactId>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-apache-jsp</artifactId>
       <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>

--- a/widgets/src/main/java/org/pentaho/gwt/widgets/client/filechooser/RepositoryFile.java
+++ b/widgets/src/main/java/org/pentaho/gwt/widgets/client/filechooser/RepositoryFile.java
@@ -23,9 +23,9 @@ import java.util.List;
 /**
  * JAXB-safe version of {@code RepositoryFile}. ({@code RepositoryFile} has no zero-arg constructor and no public
  * mutators.)
- * 
+ *
  * @see RepositoryFileAdapter
- * 
+ *
  * @author mlowery
  */
 
@@ -106,7 +106,7 @@ public class RepositoryFile implements Serializable {
 
   private static String JSONValueToString( JSONObject jso, String fieldName ) {
     JSONValue temp = jso.get( fieldName );
-    if ( temp != null ) {
+    if ( temp != null && temp.isString() != null ) {
       return temp.isString().stringValue();
     }
     return null;
@@ -114,7 +114,7 @@ public class RepositoryFile implements Serializable {
 
   private static Date JSONValueToDate( JSONObject jso, String fieldName ) {
     JSONValue temp = jso.get( fieldName );
-    if ( temp != null ) {
+    if ( temp != null && temp.isString() != null ) {
       return parseDateTime( temp.isString().stringValue() );
     }
     return null;
@@ -122,24 +122,30 @@ public class RepositoryFile implements Serializable {
 
   private static long JSONValueToLong( JSONObject jso, String fieldName ) {
     JSONValue temp = jso.get( fieldName );
-    if ( temp != null ) {
+    if ( temp != null  && temp.isString() != null ) {
       return Long.valueOf( temp.isString().stringValue() );
+    } else if ( temp != null && temp.isNumber() != null ) {
+      return Long.valueOf( temp.isNumber().toString() );
     }
     return 0;
   }
 
   private static int JSONValueToInt( JSONObject jso, String fieldName ) {
     JSONValue temp = jso.get( fieldName );
-    if ( temp != null ) {
+    if ( temp != null && temp.isString() != null ) {
       return Integer.valueOf( temp.isString().stringValue() );
+    } else if ( temp != null && temp.isNumber() != null ) {
+      return Integer.valueOf( temp.isNumber().toString() );
     }
     return 0;
   }
 
   private static boolean JSONValueToBoolean( JSONObject jso, String fieldName ) {
     JSONValue temp = jso.get( fieldName );
-    if ( temp != null ) {
+    if ( temp != null && temp.isString() != null ) {
       return Boolean.valueOf( temp.isString().stringValue() );
+    } else if ( temp != null && temp.isBoolean() != null ) {
+      return temp.isBoolean().booleanValue();
     }
     return false;
   }


### PR DESCRIPTION
This pull request includes updates to dependencies and enhancements to JSON parsing logic in the codebase. The most notable changes involve migrating from `javax.validation` to `jakarta.validation`, upgrading Jetty dependencies to EE10 versions, and improving the type-checking logic in JSON value extraction methods.

### Dependency Updates:

* [`assemblies/widgets/pom.xml`](diffhunk://#diff-45a7b98304e2bbeb04345351ce9f048ea099defaac9d0546b710cfdcf650d5e8L38-R44): Replaced `javax.validation` dependencies with `jakarta.validation` equivalents to align with newer standards.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L95-R102): Updated `javax.validation` dependencies to `jakarta.validation` and parameterized the version using `${jakarta.validation.version}` for better maintainability.
* [`widgets/pom.xml`](diffhunk://#diff-2a27fe1778b40135064d209498ac2295b63363d0133d7c476c5f4d756e77aa4aL125-R138): Migrated Jetty dependencies (`jetty-webapp`, `jetty-annotations`, `apache-jsp`) to their EE10 counterparts (`jetty-ee10-webapp`, `jetty-ee10-annotations`, `jetty-ee10-apache-jsp`) for compatibility with Jakarta EE 10.

### Code Enhancements:

* [`widgets/src/main/java/org/pentaho/gwt/widgets/client/filechooser/RepositoryFile.java`](diffhunk://#diff-902d23c862bde4be5947895f3d2cd5f027de9f60289770595780872ccbc8d379L109-R148): Improved JSON value extraction methods (`JSONValueToString`, `JSONValueToDate`, `JSONValueToLong`, `JSONValueToInt`, `JSONValueToBoolean`) by adding type checks for `isString`, `isNumber`, and `isBoolean`, ensuring robust handling of different JSON value types.