### PR TITLE
[BACKLOG-43902]-Java 21 : compatibility check for Pentaho and fix Build and Run time issues while building / testing

### DIFF
--- a/widgets/pom.xml
+++ b/widgets/pom.xml
@@ -22,7 +22,6 @@
     <webjars.target.directory>${build.dependenciesDirectory}/META-INF/resources/webjars</webjars.target.directory>
     <colt.version>1.2.0</colt.version>
     <ant.version>1.10.0</ant.version>
-    <javassist.version>3.20.0-GA</javassist.version>
     <htmlunit.version>2.19</htmlunit.version>
     <tapestry-framework.version>4.1.6</tapestry-framework.version>
     <maven-surefire-plugin.argLine> --add-opens=java.base/java.lang=ALL-UNNAMED </maven-surefire-plugin.argLine>

--- a/widgets/pom.xml
+++ b/widgets/pom.xml
@@ -40,6 +40,12 @@
       <artifactId>gwt-user</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <version>${javassist.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-incubator</artifactId>
       <version>${gwt-incubator.version}</version>


### PR DESCRIPTION
This pull request makes a minor adjustment to the `widgets/pom.xml` file by updating how the `javassist` dependency is managed, specifically moving it to the test scope and ensuring it is explicitly listed as a dependency.

Dependency management:

* Removed the `javassist.version` property from the properties section, likely because it is now only used in the test dependency declaration.
* Added `javassist` as a test-scoped dependency to the dependencies section, ensuring it is only included during testing.