### PR TITLE
feat[BISERVER-15478]: add margin and italic style to schedule label

### DIFF
--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/public/Widgets.css
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/public/Widgets.css
@@ -1007,6 +1007,10 @@ input[type=password]:focus {
   margin-left: 5px;
   margin-top: 1px;
 }
+.schedule-label:where(.schedule-parameter-defaults-note) {
+  margin-top: 12px;
+  font-style: italic;
+}
 
 .schedule-input, .schedule-button, .schedule-custom-list {
   box-sizing: border-box;


### PR DESCRIPTION
This pull request makes a minor styling adjustment to the `Widgets.css` file. It introduces a new CSS rule to add spacing and italic styling to elements with both the `schedule-label` class and the `schedule-parameter-defaults-note` class.

* Added a new CSS rule to style `.schedule-label` elements that also have the `.schedule-parameter-defaults-note` class, giving them a top margin and italic font style.