### PR TITLE
feat[SP-7233]: add margin and italic style to schedule label

### DIFF
--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/public/Widgets.css
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/public/Widgets.css
@@ -1007,6 +1007,10 @@ input[type=password]:focus {
   margin-left: 5px;
   margin-top: 1px;
 }
+.schedule-label:where(.schedule-parameter-defaults-note) {
+  margin-top: 12px;
+  font-style: italic;
+}
 
 .schedule-input, .schedule-button, .schedule-custom-list {
   box-sizing: border-box;


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7233 - Backport of BISERVER-15478 - (10.2 Suite) Scheduled Kettle Jobs and Transformations Do Not Reflect Updated kettle.properties Values Without Rescheduling](https://hv-eng.atlassian.net/browse/SP-7233)
- **Base Case:** [BISERVER-15478 - Backport of BISERVER-15478 - (10.2 Suite) Scheduled Kettle Jobs and Transformations Do Not Reflect Updated kettle.properties Values Without Rescheduling](https://hv-eng.atlassian.net/browse/BISERVER-15478)
- **Original Master PR:** https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1076

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1076
- Commit: not provided

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
