### PR TITLE
feat[SP-7232]: add margin and italic style to schedule label

### DIFF
--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/public/Widgets.css
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/public/Widgets.css
@@ -1007,6 +1007,10 @@ input[type=password]:focus {
   margin-left: 5px;
   margin-top: 1px;
 }
+.schedule-label:where(.schedule-parameter-defaults-note) {
+  margin-top: 12px;
+  font-style: italic;
+}
 
 .schedule-input, .schedule-button, .schedule-custom-list {
   box-sizing: border-box;


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7232 - Backport of BISERVER-15478 - (11.0 Suite) Scheduled Kettle Jobs and Transformations Do Not Reflect Updated kettle.properties Values Without Rescheduling](https://hv-eng.atlassian.net/browse/SP-7232)
- **Base Case:** [BISERVER-15478 - Backport of BISERVER-15478 - (11.0 Suite) Scheduled Kettle Jobs and Transformations Do Not Reflect Updated kettle.properties Values Without Rescheduling](https://hv-eng.atlassian.net/browse/BISERVER-15478)
- **Original Master PR:** https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1076

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1076
- Commit: 150615a917cc1830ea1cc288b4e59dda1f162c37

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
