### PR TITLE
build[SP-7224]: Bump version of validation-api dependency to 1.1.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,17 +104,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>javax.validation</groupId>
-        <artifactId>validation-api</artifactId>
-        <version>1.0.0.GA</version>
-      </dependency>
-      <dependency>
-        <groupId>javax.validation</groupId>
-        <artifactId>validation-api</artifactId>
-        <version>1.0.0.GA</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
         <version>${com.github.spotbugs.annotations.version}</version>


### PR DESCRIPTION
## Summary
- remove repo-local javax.validation:validation-api version ownership
- inherit javax.validation:validation-api 1.1.0.Final from pentaho-parent-pom on 10.2