### PR TITLE
fix[SP-7224]: Fix incompatibility with validation-api 1.1.0.Final bump

### DIFF
--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/ValidationCompat.gwt.xml
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/ValidationCompat.gwt.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module>
+  <!--
+    Super-source override for javax.validation.Path.
+
+    Replaces javax.validation.Path with a GWT-translatable version that only exposes the
+    Bean Validation 1.0 API surface (no getKind() / as()). This prevents the GWT compiler
+    from requiring those 1.1.0.Final additions when it compiles gwt-user's own NodeImpl.
+
+    See: super/javax/validation/Path.java
+  -->
+  <super-source path="super"/>
+</module>

--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/Widgets.gwt.xml
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/Widgets.gwt.xml
@@ -1,30 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module>
 
-      <!-- Inherit the core Web Toolkit stuff.                        -->
-      <inherits name='com.google.gwt.user.User'/>
-	  <inherits name="com.google.gwt.xml.XML"/>
-	  <inherits name="com.google.gwt.json.JSON" />
-      <!-- required for date picker control -->
-      <inherits name='com.google.gwt.widgetideas.WidgetIdeas'/>
-      <inherits name='com.google.gwt.widgetideas.ScrollTable'/>
+    <!-- Inherit the core Web Toolkit stuff.                        -->
+    <inherits name='com.google.gwt.user.User'/>
+    <!--
+      ValidationCompat: GWT compatibility shim for validation-api 1.1.0.Final.
 
-      <inherits name='com.allen_sauer.gwt.dnd.gwt-dnd'/>
-      <inherits name="org.adamtacy.GWTEffects"/>
-      <inherits name="org.pentaho.mantle.client.environment.Environment"/>
+      validation-api 1.1.0.Final added Path.Node#getKind() and Path.Node#as(Class) which are not
+      implemented by gwt-user's bundled NodeImpl (written against the 1.0 API). Without this shim
+      the GWT compiler fails with "must implement inherited abstract method" errors when compiling
+      gwt-user's own translatable source.
 
-      <!-- Inherit the default GWT style sheet.  You can change       -->
-      <!-- the theme of your GWT application by uncommenting          -->
-      <!-- any one of the following lines.                            -->
-      <!-- inherits name='com.google.gwt.user.theme.standard.Standard'/> -->
-      <!-- <inherits name="com.google.gwt.user.theme.chrome.Chrome"/> -->
-      <!-- <inherits name="com.google.gwt.user.theme.dark.Dark"/>     -->
+      ValidationCompat.gwt.xml uses <super-source> to replace javax.validation.Path with a
+      GWT-only version that exposes only the 1.0 API surface. The JVM classpath is unaffected.
 
-      <!-- Other module inherits                                      -->
+      See: widgets/src/main/resources/org/pentaho/gwt/widgets/super/javax/validation/Path.java
+    -->
+    <inherits name="org.pentaho.gwt.widgets.ValidationCompat"/>
+    <inherits name="com.google.gwt.xml.XML"/>
+    <inherits name="com.google.gwt.json.JSON" />
+    <!-- required for date picker control -->
+    <inherits name='com.google.gwt.widgetideas.WidgetIdeas'/>
+    <inherits name='com.google.gwt.widgetideas.ScrollTable'/>
 
-      <!-- Specify the application specific style sheet.              -->
-      <!-- Specify the app entry point class.                   -->
-	  <entry-point class='org.pentaho.gwt.widgets.client.WidgetModule'/>
+    <inherits name='com.allen_sauer.gwt.dnd.gwt-dnd'/>
+    <inherits name="org.adamtacy.GWTEffects"/>
+    <inherits name="org.pentaho.mantle.client.environment.Environment"/>
+
+    <!-- Inherit the default GWT style sheet.  You can change       -->
+    <!-- the theme of your GWT application by uncommenting          -->
+    <!-- any one of the following lines.                            -->
+    <!-- inherits name='com.google.gwt.user.theme.standard.Standard'/> -->
+    <!-- <inherits name="com.google.gwt.user.theme.chrome.Chrome"/> -->
+    <!-- <inherits name="com.google.gwt.user.theme.dark.Dark"/>     -->
+
+    <!-- Other module inherits                                      -->
+
+    <!-- Specify the application specific style sheet.              -->
+    <!-- Specify the app entry point class.                   -->
+    <entry-point class='org.pentaho.gwt.widgets.client.WidgetModule'/>
     <entry-point class='org.pentaho.gwt.widgets.client.filechooser.FileChooserEntryPoint'/>
 
     <public path="public"/>

--- a/widgets/src/main/resources/org/pentaho/gwt/widgets/super/javax/validation/Path.java
+++ b/widgets/src/main/resources/org/pentaho/gwt/widgets/super/javax/validation/Path.java
@@ -1,0 +1,51 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2028-08-13
+ ******************************************************************************/
+
+
+package javax.validation;
+
+/**
+ * GWT super-source override of {@code javax.validation.Path}.
+ *
+ * <p><b>Why this file exists:</b> {@code validation-api 1.1.0.Final} added two new methods to the
+ * {@code Path.Node} interface — {@code getKind()} and {@code as(Class<T>)} — that were not present
+ * in {@code 1.0.0.GA}. The GWT runtime jar ({@code gwt-user-2.x}) bundles its own translatable
+ * implementation of {@code Path.Node} ({@code NodeImpl}) that only satisfies the 1.0 API surface.
+ * When the GWT compiler processes the bundled {@code NodeImpl} source against the 1.1 jar it fails
+ * with "must implement inherited abstract method Path.Node.getKind()".
+ *
+ * <p><b>Fix:</b> This super-source file replaces {@code javax.validation.Path} <em>for GWT
+ * translatable code only</em> with a version that exposes only the 1.0 API shape, allowing
+ * {@code gwt-user}'s {@code NodeImpl} to compile cleanly. The regular JVM classpath is unaffected
+ * and continues to use the full {@code 1.1.0.Final} jar at runtime.
+ *
+ * <p><b>Referenced by:</b> {@code ValidationCompat.gwt.xml} via {@code <super-source path="super"/>}.
+ *
+ * <p><b>Do not add {@code getKind()} or {@code as(Class)} here.</b> Doing so would re-introduce
+ * the compile failure in {@code gwt-user}'s {@code NodeImpl}.
+ */
+public interface Path extends Iterable<Path.Node> {
+
+  /**
+   * Represents a single node (element) in a property path.
+   * Intentionally limited to the Bean Validation 1.0 API surface.
+   */
+  interface Node {
+    String getName();
+
+    boolean isInIterable();
+
+    Integer getIndex();
+
+    Object getKey();
+  }
+}


### PR DESCRIPTION
This pull request introduces a GWT compatibility shim to resolve issues with the `validation-api` upgrade from 1.0 to 1.1, specifically addressing the GWT compiler errors caused by new methods in `Path.Node`. The solution uses GWT's super-source mechanism to provide a GWT-only version of `javax.validation.Path` that matches the 1.0 API, ensuring compatibility with the GWT runtime while leaving the JVM classpath unchanged.

**GWT Validation API compatibility:**

* Added a new GWT module definition file `ValidationCompat.gwt.xml` that uses `<super-source>` to override `javax.validation.Path` for GWT builds, exposing only the 1.0 API surface.
* Updated `Widgets.gwt.xml` to inherit the new `ValidationCompat` module, including detailed documentation on why the shim is necessary and how it works.
* Introduced a GWT-specific super-source implementation of `javax.validation.Path` and its nested `Node` interface, intentionally omitting the `getKind()` and `as(Class)` methods to maintain compatibility with GWT's bundled `NodeImpl`.